### PR TITLE
Separate `orbiter analyze` Command, add input file to dag dict post-filter, trim log output

### DIFF
--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any, Tuple
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 version = __version__
 

--- a/orbiter/__main__.py
+++ b/orbiter/__main__.py
@@ -54,6 +54,43 @@ logger.add(
     **(exceptions_off if LOG_LEVEL != "DEBUG" else exceptions_on),
 )
 
+INPUT_DIR_ARGS = ("input-dir",)
+INPUT_DIR_KWARGS = dict(
+    type=click.Path(
+        exists=True,
+        dir_okay=True,
+        file_okay=False,
+        readable=True,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=Path.cwd() / "workflow",
+    required=True,
+)
+RULESET_ARGS = (
+    "-r",
+    "--ruleset",
+)
+RULESET_KWARGS = dict(
+    help="Qualified name of a TranslationRuleset",
+    type=str,
+    prompt="Ruleset to use? (e.g. orbiter_community_translations.dag_factory.translation_ruleset)",
+    required=True,
+)
+
+
+def import_ruleset(ruleset: str) -> TranslationRuleset:
+    if RUNNING_AS_BINARY:
+        _add_pyz()
+
+    logger.debug(f"Importing ruleset: {ruleset}")
+    (_, translation_ruleset) = import_from_qualname(ruleset)
+    if not isinstance(translation_ruleset, TranslationRuleset):
+        raise RuntimeError(
+            f"translation_ruleset={translation_ruleset} is not a TranslationRuleset"
+        )
+    return translation_ruleset
+
 
 def run(cmd: str, **kwargs):
     """Helper method to run a command and log the output"""
@@ -124,19 +161,7 @@ def orbiter():
 
 
 @orbiter.command()
-@click.argument(
-    "input-dir",
-    type=click.Path(
-        exists=True,
-        dir_okay=True,
-        file_okay=False,
-        readable=True,
-        resolve_path=True,
-        path_type=Path,
-    ),
-    default=Path.cwd() / "workflow",
-    required=True,
-)
+@click.argument(*INPUT_DIR_ARGS, **INPUT_DIR_KWARGS)
 @click.argument(
     "output-dir",
     type=click.Path(
@@ -149,14 +174,7 @@ def orbiter():
     default=Path.cwd() / "output",
     required=True,
 )
-@click.option(
-    "-r",
-    "--ruleset",
-    help="Qualified name of a TranslationRuleset",
-    type=str,
-    prompt="Ruleset to use? (e.g. orbiter_community_translations.dag_factory.translation_ruleset)",
-    required=True,
-)
+@click.option(*RULESET_ARGS, **RULESET_KWARGS)
 @click.option(
     "--format/--no-format",
     "_format",
@@ -164,18 +182,11 @@ def orbiter():
     default=True,
     show_default=True,
 )
-@click.option(
-    "--analyze/--no-analyze",
-    help="[optional] print statistics instead of rendering output",
-    default=False,
-    show_default=True,
-)
 def translate(
     input_dir: Path,
     output_dir: Path,
     ruleset: str | None,
     _format: bool,
-    analyze: bool,
 ):
     """Translate workflows in an `INPUT_DIR` to an `OUTPUT_DIR` Airflow Project.
 
@@ -192,32 +203,61 @@ def translate(
     logger.debug(f"Creating output directory {output_dir}")
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    logger.debug(f"Adding current directory {os.getcwd()} to sys.path")
-    sys.path.insert(0, os.getcwd())
-
-    if RUNNING_AS_BINARY:
-        _add_pyz()
-
-    logger.debug(f"Importing ruleset: {ruleset}")
-    (_, translation_ruleset) = import_from_qualname(ruleset)
-    if not isinstance(translation_ruleset, TranslationRuleset):
-        raise RuntimeError(
-            f"translation_ruleset={translation_ruleset} is not a TranslationRuleset"
-        )
-
+    translation_ruleset = import_ruleset(ruleset)
     try:
-        project = translation_ruleset.translate_fn(
+        translation_ruleset.translate_fn(
             translation_ruleset=translation_ruleset, input_dir=input_dir
-        )
-        if analyze:
-            project.analyze()
-        else:
-            project.render(output_dir)
+        ).render(output_dir)
     except RuntimeError as e:
         logger.error(f"Error encountered during translation: {e}")
         raise click.Abort()
     if _format:
         run_ruff_formatter(output_dir)
+
+
+@orbiter.command()
+@click.argument(*INPUT_DIR_ARGS, **INPUT_DIR_KWARGS)
+@click.option(*RULESET_ARGS, **RULESET_KWARGS)
+@click.option(
+    "--format",
+    "_format",
+    type=click.Choice(["json", "csv", "md"]),
+    default="md",
+    help="[optional] format for analysis output",
+    show_default=True,
+)
+@click.option(
+    "-o",
+    "--output-file",
+    type=click.File("w", lazy=True),
+    default="-",
+    show_default=True,
+    help="File to write to, defaults to '-' (stdout)",
+)
+def analyze(
+    input_dir: Path,
+    ruleset: str | None,
+    _format: Literal["json", "csv", "md"],
+    output_file: Path | None,
+):
+    """Analyze workflows in an `INPUT_DIR`
+
+    Provide a specific ruleset with the `--ruleset` flag.
+
+    Run `orbiter list-rulesets` to see available rulesets.
+
+    `INPUT_DIR` defaults to `$CWD/workflow`.
+    """
+    if isinstance(output_file, Path):
+        output_file = output_file.open("w", newline="")
+    translation_ruleset = import_ruleset(ruleset)
+    try:
+        translation_ruleset.translate_fn(
+            translation_ruleset=translation_ruleset, input_dir=input_dir
+        ).analyze(_format, output_file)
+    except RuntimeError as e:
+        logger.exception(f"Error encountered during translation: {e}")
+        raise click.Abort()
 
 
 def _pip_install(repo: str, key: str):
@@ -278,6 +318,9 @@ def _get_gh_pyz(
 
 
 def _add_pyz():
+    logger.debug(f"Adding current directory {os.getcwd()} to sys.path")
+    sys.path.insert(0, os.getcwd())
+
     local_pyz = [
         str(_path.resolve()) for _path in Path(".").iterdir() if _path.suffix == ".pyz"
     ]

--- a/orbiter/config.py
+++ b/orbiter/config.py
@@ -10,5 +10,8 @@ ORBITER_TASK_SUFFIX = os.getenv("ORBITER_TASK_SUFFIX", "_task")
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
 """You can set the log level to DEBUG to see more detailed logs."""
 
+TRIM_LOG_OBJECT_LENGTH = os.getenv("TRIM_LOG_OBJECT_LENGTH", 1000)
+"""Trim the (str) length of logged objects to avoid long logs, set to -1 to disable trimming and log full objects."""
+
 KG_ACCOUNT_ID = "3b189b4c-c047-4fdb-9b46-408aa2978330"
 RUNNING_AS_BINARY = getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS")

--- a/orbiter/objects/dag.py
+++ b/orbiter/objects/dag.py
@@ -174,6 +174,30 @@ class OrbiterDAG(OrbiterASTBase, OrbiterBase, extra="allow"):
             f"catchup={self.catchup})"
         )
 
+    # noinspection t
+    def __add__(self, other):
+        if other.tasks:
+            for task in other.tasks.values():
+                self.add_tasks(task)
+        if other.orbiter_conns:
+            for conn in other.orbiter_conns:
+                self.orbiter_conns.add(conn)
+        if other.orbiter_vars:
+            for var in other.orbiter_vars:
+                self.orbiter_vars.add(var)
+        if other.orbiter_env_vars:
+            for env_var in other.orbiter_env_vars:
+                self.orbiter_env_vars.add(env_var)
+        if other.orbiter_includes:
+            for include in other.orbiter_includes:
+                self.orbiter_includes.add(include)
+        if other.model_extra:
+            for key in other.model_extra.keys():
+                self.model_extra[key] = self.model_extra[key] or other.model_extra[key]
+        for key in self.render_attributes:
+            setattr(self, key, getattr(self, key) or getattr(other, key))
+        return self
+
     def _dag_to_ast(self) -> ast.Expr:
         """
         Returns the `DAG(...)` object.

--- a/orbiter/rules/__init__.py
+++ b/orbiter/rules/__init__.py
@@ -52,12 +52,13 @@ from __future__ import annotations
 import functools
 import json
 import re
-from typing import Callable, Any, Collection, TYPE_CHECKING, List
+from typing import Callable, Any, Collection, TYPE_CHECKING, List, Mapping
 
 from pydantic import BaseModel, Field
 
 from loguru import logger
 
+from config import TRIM_LOG_OBJECT_LENGTH
 from orbiter.objects.task import OrbiterOperator, OrbiterTaskDependency
 
 if TYPE_CHECKING:
@@ -67,6 +68,17 @@ if TYPE_CHECKING:
 
 qualname_validator_regex = r"^[\w.]+$"
 qualname_validator = re.compile(qualname_validator_regex)
+
+
+def trim_dict(v):
+    """Stringify and trim a dictionary if it's greater than a certain length
+    (used to trim down overwhelming log output)"""
+    if TRIM_LOG_OBJECT_LENGTH != -1 and isinstance(v, Mapping):
+        if len(str(v)) > TRIM_LOG_OBJECT_LENGTH:
+            return json.dumps(v, default=str)[:TRIM_LOG_OBJECT_LENGTH] + "..."
+    if isinstance(v, list):
+        return [trim_dict(_v) for _v in v]
+    return v
 
 
 def rule(
@@ -160,7 +172,9 @@ class Rule(BaseModel, Callable, extra="forbid"):
                     setattr(result, "orbiter_kwargs", kwargs)
         except Exception as e:
             logger.warning(
-                f"[RULE]: {self.rule.__name__}\n[ERROR]:\n{type(e)} - {e}\n[INPUT]:\n{args}\n{kwargs}"
+                f"[RULE]: {self.rule.__name__}\n"
+                f"[ERROR]:\n{type(e)} - {trim_dict(e)}\n"
+                f"[INPUT]:\n{trim_dict(args)}\n{trim_dict(kwargs)}"
             )
             result = None
         return result
@@ -314,7 +328,7 @@ def cannot_map_rule(val: dict) -> OrbiterOperator | None:
     # noinspection PyArgumentList
     return OrbiterEmptyOperator(
         task_id="UNKNOWN",
-        doc_md=f"""Input did not translate: `{json.dumps(val, default=str)}`""",
+        doc_md=f"""[task_type=UNKNOWN] Input did not translate: `{trim_dict(val)}`""",
     )
 
 

--- a/orbiter/rules/__init__.py
+++ b/orbiter/rules/__init__.py
@@ -203,6 +203,10 @@ dag_filter_rule: Callable[[...], DAGFilterRule] = rule
 class DAGRule(Rule):
     """A `@dag_rule` decorator creates a [`DAGRule`][orbiter.rules.DAGRule]
 
+    !!! tip
+
+        A `__file` key is added to the original input, which is the file path of the input.
+
     ```python
     @dag_rule
     def foo(val: dict) -> OrbiterDAG | None:

--- a/orbiter/rules/__init__.py
+++ b/orbiter/rules/__init__.py
@@ -58,7 +58,7 @@ from pydantic import BaseModel, Field
 
 from loguru import logger
 
-from config import TRIM_LOG_OBJECT_LENGTH
+from orbiter.config import TRIM_LOG_OBJECT_LENGTH
 from orbiter.objects.task import OrbiterOperator, OrbiterTaskDependency
 
 if TYPE_CHECKING:

--- a/orbiter/rules/rulesets.py
+++ b/orbiter/rules/rulesets.py
@@ -656,7 +656,11 @@ class TranslationRuleset(BaseModel, ABC, extra="forbid"):
             if file.suffix.lower() in {
                 f".{ext.lower()}" for ext in file_type.extension
             }:
-                return file_type.load_fn(file.read_text())
+                try:
+                    return file_type.load_fn(file.read_text())
+                except Exception as e:
+                    logger.error(f"Error loading file={file}! Skipping!\n{e}")
+                    continue
         raise TypeError(
             f"Invalid file_type={file.suffix}, does not match file_type={self.file_type}"
         )
@@ -705,9 +709,6 @@ class TranslationRuleset(BaseModel, ABC, extra="forbid"):
                     )
                 except TypeError:
                     logger.debug(f"File={file} not of correct type, skipping...")
-                    continue
-                except Exception as e:
-                    logger.exception(f"Error loading file={file}, {e}")
                     continue
 
     def test(self, input_value: str | dict) -> OrbiterProject:

--- a/orbiter/rules/rulesets.py
+++ b/orbiter/rules/rulesets.py
@@ -39,7 +39,8 @@ from orbiter.rules import (
     TaskDependencyRule,
     PostProcessingRule,
     EMPTY_RULE,
-)  # noqa: F401
+    trim_dict,
+)
 
 
 def _backport_walk(input_dir: Path):
@@ -203,8 +204,6 @@ def translate(translation_ruleset, input_dir: Path) -> OrbiterProject:
         other rules have been applied.
     6. After translation - the [`OrbiterProject`][orbiter.objects.project.OrbiterProject]
         is rendered to the output folder.
-
-
     """
     if not isinstance(translation_ruleset, TranslationRuleset):
         raise RuntimeError(
@@ -271,7 +270,9 @@ def translate(translation_ruleset, input_dir: Path) -> OrbiterProject:
                 or []
             )
             if not len(task_dependencies):
-                logger.warning(f"Couldn't find task dependencies in dag={dag_dict}")
+                logger.warning(
+                    f"Couldn't find task dependencies in " f"dag={trim_dict(dag_dict)}"
+                )
             for task_dependency in task_dependencies:
                 task_dependency: OrbiterTaskDependency
                 if task_dependency.task_id not in dag.tasks:
@@ -501,8 +502,8 @@ class Ruleset(BaseModel, frozen=True, extra="forbid"):
                     "---------\n"
                     f"[RULESET MATCHED] '{self.__class__.__module__}.{self.__class__.__name__}'\n"
                     f"[RULE MATCHED] '{_rule.__name__}'\n"
-                    f"[INPUT] {kwargs if should_show_input else '<Skipping...>'}\n"
-                    f"[RETURN] {result}\n"
+                    f"[INPUT] {trim_dict(kwargs) if should_show_input else '<Skipping...>'}\n"
+                    f"[RETURN] {trim_dict(result)}\n"
                     f"---------"
                 )
                 results.append(result)


### PR DESCRIPTION
- feat: add trim_dict to reduce log output of large objects
- refactor: separate `orbiter analyze` into it's own command
- fix: allow adding DAGs together (if parts were in multiple files)
- feat: `orbiter analyze` - write to file & get unknown task type from doc_md
- feat: add `__file` key to dag dict after filter. Make orbiter_kwargs[file_path] relative to input_dir
- fix: continue (w/ error) for failure to load a file of type
- fix: fix import path