### PR TITLE
v1.2.3

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ To extend or customize an existing ruleset, you can easily modify it with simple
         └── ...
     ```
 3. Add contents to `override.py`:
-   ```python title="override.py" linenums="1"
+    ```python title="override.py" linenums="1"
     -8<- "tests/resources/override/override.py"
     ```
     1. Importing specific translation ruleset, determined via the [Origins](origins.md) page

--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any, Tuple
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 version = __version__
 

--- a/orbiter/ast_helper.py
+++ b/orbiter/ast_helper.py
@@ -35,14 +35,14 @@ def py_bitshift(
     )
 
 
-def py_assigned_object(name: str, obj: str, **kwargs) -> ast.Assign:
+def py_assigned_object(ast_name: str, obj: str, **kwargs) -> ast.Assign:
     """
-    >>> render_ast(py_assigned_object("foo", "Bar", baz="bop"))
+    >>> render_ast(py_assigned_object("foo","Bar",baz="bop"))
     "foo = Bar(baz='bop')"
     """
     return ast.Assign(
         lineno=0,
-        targets=[ast.Name(id=name)],
+        targets=[ast.Name(id=ast_name)],
         value=ast.Call(
             func=ast.Name(id=obj),
             args=[],

--- a/orbiter/objects/dag.py
+++ b/orbiter/objects/dag.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ast
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import reduce
 from pathlib import Path
 from typing import Annotated, Any, Dict, Iterable, List, Callable
@@ -143,7 +143,7 @@ class OrbiterDAG(OrbiterASTBase, OrbiterBase, extra="allow"):
     file_path: str | Path
 
     dag_id: DagId
-    schedule: str | OrbiterTimetable | None = None
+    schedule: str | timedelta | OrbiterTimetable | None = None
     catchup: bool = False
     start_date: DateTime | datetime = DateTime(1970, 1, 1)
     tags: List[str] = None

--- a/orbiter/objects/task_group.py
+++ b/orbiter/objects/task_group.py
@@ -129,6 +129,10 @@ class OrbiterTaskGroup(OrbiterASTBase, OrbiterBase, ABC, extra="forbid"):
         return py_with(
             py_object("TaskGroup", group_id=self.task_group_id).value,
             [operator._to_ast() for operator in self.tasks]
-            + [operator._downstream_to_ast() for operator in self.tasks],
+            + [
+                downstream
+                for operator in self.tasks
+                if (downstream := operator._downstream_to_ast())
+            ],
             self.task_group_id,
         )

--- a/orbiter/rules/rulesets.py
+++ b/orbiter/rules/rulesets.py
@@ -221,7 +221,7 @@ def translate(translation_ruleset, input_dir: Path) -> OrbiterProject:
 
         # DAG FILTER Ruleset - filter down to keys suspected of being translatable to a DAG, in priority order.
         # Add __file DAG FILTER inputs and outputs, so it's available for both DAG and DAG FILTER rules
-        __file_addition = {"__file": file.relative_to(input_dir)}
+        __file_addition = {"__file": (input_dir / file.relative_to(input_dir))}
         dag_dicts: List[dict] = [
             __file_addition | dag_dict
             for dag_dict in functools.reduce(


### PR DESCRIPTION
- fix: change 'name' in `py_assigned_object` to 'ast_name' to prevent collision if used in a task
- feat: add __file before and after dag_filter
- fix: allow OrbiterDAG to take timedelta
- fix: remove empty downstreams from TaskGroup to prevent ast render failures