### PR TITLE
Improve behavior around adding nested TaskDependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,7 @@ repos:
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
-
-  - repo: https://github.com/psf/black
-    rev: 24.10.0
-    hooks: [ { id: black, args: [ --config=pyproject.toml ] } ]
+      - id: ruff-format
 
   - repo: https://github.com/PyCQA/bandit/
     rev: 1.7.10

--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any, Tuple
 
-__version__ = "1.2.3"
+__version__ = "1.3.0"
 
 version = __version__
 
@@ -44,16 +44,14 @@ def import_from_qualname(qualname) -> Tuple[str, Any]:
     """Import a function or module from a qualified name
     :param qualname: The qualified name of the function or module to import (e.g. a.b.d.MyOperator or json)
     :return Tuple[str, Any]: The name of the function or module, and the function or module itself
-    >>> import_from_qualname('json.loads')
+    >>> import_from_qualname("json.loads")
     ('loads', <function loads at ...>)
-    >>> import_from_qualname('json')
+    >>> import_from_qualname("json")
     ('json', <module 'json' from '...'>)
     """
     from importlib import import_module
 
-    [module, name] = (
-        qualname.rsplit(".", 1) if "." in qualname else [qualname, qualname]
-    )
+    [module, name] = qualname.rsplit(".", 1) if "." in qualname else [qualname, qualname]
     imported_module = import_module(module)
     return (
         name,
@@ -64,8 +62,4 @@ def import_from_qualname(qualname) -> Tuple[str, Any]:
 if __name__ == "__main__":
     import doctest
 
-    doctest.testmod(
-        optionflags=doctest.ELLIPSIS
-        | doctest.NORMALIZE_WHITESPACE
-        | doctest.IGNORE_EXCEPTION_DETAIL
-    )
+    doctest.testmod(optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL)

--- a/orbiter/__main__.py
+++ b/orbiter/__main__.py
@@ -34,9 +34,7 @@ def formatter(r):
     return (
         "<lvl>"
         + (  # add [time] WARN, etc. if it's not INFO
-            "[{time:HH:mm:ss}|{level}] "
-            if r["level"].no != logging.INFO
-            else "[{time:HH:mm:ss}] "
+            "[{time:HH:mm:ss}|{level}] " if r["level"].no != logging.INFO else "[{time:HH:mm:ss}] "
         )
         + "{message}</>\n{exception}"  # add exception, if there is one
     )
@@ -86,9 +84,7 @@ def import_ruleset(ruleset: str) -> TranslationRuleset:
     logger.debug(f"Importing ruleset: {ruleset}")
     (_, translation_ruleset) = import_from_qualname(ruleset)
     if not isinstance(translation_ruleset, TranslationRuleset):
-        raise RuntimeError(
-            f"translation_ruleset={translation_ruleset} is not a TranslationRuleset"
-        )
+        raise RuntimeError(f"translation_ruleset={translation_ruleset} is not a TranslationRuleset")
     return translation_ruleset
 
 
@@ -115,20 +111,14 @@ def run_ruff_formatter(output_dir: Path):
         changed_files = " ".join(
             (
                 file
-                for file in git.Repo(output_dir)
-                .git.diff(output_dir, name_only=True)
-                .split("\n")
+                for file in git.Repo(output_dir).git.diff(output_dir, name_only=True).split("\n")
                 if file.endswith(".py")
             )
         )
     except ImportError:
-        logger.debug(
-            "Unable to acquire list of changed files in output directory, reformatting output directory..."
-        )
+        logger.debug("Unable to acquire list of changed files in output directory, reformatting output directory...")
     except Exception:
-        logger.debug(
-            "Unable to acquire list of changed files in output directory, reformatting output directory..."
-        )
+        logger.debug("Unable to acquire list of changed files in output directory, reformatting output directory...")
 
     output = run(
         f"ruff check --select E,F,UP,B,SIM,I --ignore E501 --fix {changed_files}",
@@ -205,9 +195,9 @@ def translate(
 
     translation_ruleset = import_ruleset(ruleset)
     try:
-        translation_ruleset.translate_fn(
-            translation_ruleset=translation_ruleset, input_dir=input_dir
-        ).render(output_dir)
+        translation_ruleset.translate_fn(translation_ruleset=translation_ruleset, input_dir=input_dir).render(
+            output_dir
+        )
     except RuntimeError as e:
         logger.error(f"Error encountered during translation: {e}")
         raise click.Abort()
@@ -252,9 +242,9 @@ def analyze(
         output_file = output_file.open("w", newline="")
     translation_ruleset = import_ruleset(ruleset)
     try:
-        translation_ruleset.translate_fn(
-            translation_ruleset=translation_ruleset, input_dir=input_dir
-        ).analyze(_format, output_file)
+        translation_ruleset.translate_fn(translation_ruleset=translation_ruleset, input_dir=input_dir).analyze(
+            _format, output_file
+        )
     except RuntimeError as e:
         logger.exception(f"Error encountered during translation: {e}")
         raise click.Abort()
@@ -266,9 +256,7 @@ def _pip_install(repo: str, key: str):
     _exec += f"=={TRANSLATION_VERSION}" if TRANSLATION_VERSION != "latest" else ""
     if repo == "astronomer-orbiter-translations":
         if not key:
-            raise ValueError(
-                "License key is required for 'astronomer-orbiter-translations'!"
-            )
+            raise ValueError("License key is required for 'astronomer-orbiter-translations'!")
         extra = f' --index-url "https://license:{key}@api.keygen.sh/v1/accounts/{KG_ACCOUNT_ID}/engines/pypi/simple"'
         _exec = f"{_exec}{extra}"
     logger.debug(_exec.replace(key or "<nothing>", "****"))
@@ -287,8 +275,7 @@ def _get_keygen_pyz(key):
         latest_orbiter_translations_pyz_id = next(
             artifact["id"]
             for artifact in r.json().get("data", [])
-            if artifact.get("attributes", {}).get("filename")
-            == "orbiter_translations.pyz"
+            if artifact.get("attributes", {}).get("filename") == "orbiter_translations.pyz"
         )
     except StopIteration:
         raise ValueError("No Artifact found with filename='orbiter_translations.pyz'")
@@ -321,9 +308,7 @@ def _add_pyz():
     logger.debug(f"Adding current directory {os.getcwd()} to sys.path")
     sys.path.insert(0, os.getcwd())
 
-    local_pyz = [
-        str(_path.resolve()) for _path in Path(".").iterdir() if _path.suffix == ".pyz"
-    ]
+    local_pyz = [str(_path.resolve()) for _path in Path(".").iterdir() if _path.suffix == ".pyz"]
     logger.debug(f"Adding local .pyz files {local_pyz} to sys.path")
     sys.path += local_pyz
 
@@ -332,9 +317,7 @@ def _bin_install(repo: str, key: str):
     """If we are running via a PyInstaller binary, we need to download a .pyz"""
     if "astronomer-orbiter-translations" in repo:
         if not key:
-            raise ValueError(
-                "License key is required for 'astronomer-orbiter-translations'!"
-            )
+            raise ValueError("License key is required for 'astronomer-orbiter-translations'!")
         _get_keygen_pyz(key)
     else:
         _get_gh_pyz()
@@ -348,9 +331,7 @@ def _bin_install(repo: str, key: str):
 @click.option(
     "-r",
     "--repo",
-    type=click.Choice(
-        ["astronomer-orbiter-translations", "orbiter-community-translations"]
-    ),
+    type=click.Choice(["astronomer-orbiter-translations", "orbiter-community-translations"]),
     required=False,
     allow_from_autoenv=True,
     show_envvar=True,
@@ -367,10 +348,7 @@ def _bin_install(repo: str, key: str):
     show_envvar=True,
 )
 def install(
-    repo: (
-        Literal["astronomer-orbiter-translations", "orbiter-community-translations"]
-        | None
-    ),
+    repo: (Literal["astronomer-orbiter-translations", "orbiter-community-translations"] | None),
     key: str | None,
 ):
     """Install a new Translation Ruleset from a repository"""
@@ -392,9 +370,7 @@ def install(
         ) == "Other":
             repo = None
             while not repo:
-                repo = Prompt.ask(
-                    "Package Name or Repository URL (e.g. git+https://github.com/my/repo.git )"
-                )
+                repo = Prompt.ask("Package Name or Repository URL (e.g. git+https://github.com/my/repo.git )")
 
     if RUNNING_AS_BINARY:
         _bin_install(repo, key)
@@ -408,13 +384,7 @@ def list_rulesets():
     console = Console()
 
     table = tabulate(
-        list(
-            DictReader(
-                pkgutil.get_data("orbiter.assets", "supported_origins.csv")
-                .decode()
-                .splitlines()
-            )
-        ),
+        list(DictReader(pkgutil.get_data("orbiter.assets", "supported_origins.csv").decode().splitlines())),
         headers="keys",
         tablefmt="pipe",
         # https://github.com/Textualize/rich/issues/3027

--- a/orbiter/ast_helper.py
+++ b/orbiter/ast_helper.py
@@ -5,9 +5,7 @@ from abc import ABC, abstractmethod
 from typing import List, Callable
 
 
-def py_bitshift(
-    left: str | List[str], right: str | List[str], is_downstream: bool = True
-):
+def py_bitshift(left: str | List[str], right: str | List[str], is_downstream: bool = True):
     """
     >>> render_ast(py_bitshift("foo", "bar", is_downstream=False))
     'foo << bar'
@@ -18,26 +16,14 @@ def py_bitshift(
     >>> render_ast(py_bitshift(["foo", "bar"], "baz"))
     '[foo, bar] >> baz'
     """
-    left = (
-        ast.Name(id=left)
-        if isinstance(left, str)
-        else ast.List(elts=[ast.Name(id=elt) for elt in left])
-    )
-    right = (
-        ast.Name(id=right)
-        if isinstance(right, str)
-        else ast.List(elts=[ast.Name(id=elt) for elt in right])
-    )
-    return ast.Expr(
-        value=ast.BinOp(
-            left=left, op=ast.RShift() if is_downstream else ast.LShift(), right=right
-        )
-    )
+    left = ast.Name(id=left) if isinstance(left, str) else ast.List(elts=[ast.Name(id=elt) for elt in left])
+    right = ast.Name(id=right) if isinstance(right, str) else ast.List(elts=[ast.Name(id=elt) for elt in right])
+    return ast.Expr(value=ast.BinOp(left=left, op=ast.RShift() if is_downstream else ast.LShift(), right=right))
 
 
 def py_assigned_object(ast_name: str, obj: str, **kwargs) -> ast.Assign:
     """
-    >>> render_ast(py_assigned_object("foo","Bar",baz="bop"))
+    >>> render_ast(py_assigned_object("foo", "Bar", baz="bop"))
     "foo = Bar(baz='bop')"
     """
     return ast.Assign(
@@ -49,11 +35,7 @@ def py_assigned_object(ast_name: str, obj: str, **kwargs) -> ast.Assign:
             keywords=[
                 ast.keyword(
                     arg=arg,
-                    value=(
-                        ast.Constant(value=value)
-                        if not isinstance(value, ast.AST)
-                        else value
-                    ),
+                    value=(ast.Constant(value=value) if not isinstance(value, ast.AST) else value),
                 )
                 for arg, value in kwargs.items()
             ],
@@ -70,10 +52,7 @@ def py_object(name: str, **kwargs) -> ast.Expr:
         value=ast.Call(
             func=ast.Name(id=name),
             args=[],
-            keywords=[
-                ast.keyword(arg=arg, value=ast.Constant(value=value))
-                for arg, value in kwargs.items()
-            ],
+            keywords=[ast.keyword(arg=arg, value=ast.Constant(value=value)) for arg, value in kwargs.items()],
         )
     )
 
@@ -86,9 +65,7 @@ def py_root(*args) -> ast.Module:
     return ast.Module(body=args, type_ignores=[])
 
 
-def py_import(
-    names: List[str], module: str = None
-) -> ast.ImportFrom | ast.Import | list:
+def py_import(names: List[str], module: str = None) -> ast.ImportFrom | ast.Import | list:
     """
     :param module: e.g. `airflow.operators.bash` for `from airflow.operators.bash import BashOperator`
     :param names: e.g. `BashOperator` for `from airflow.operators.bash import BashOperator`
@@ -100,28 +77,31 @@ def py_import(
     'import json'
     """
     if module is not None:
-        return ast.ImportFrom(
-            module=module, names=[ast.alias(name=name) for name in names], level=0
-        )
+        return ast.ImportFrom(module=module, names=[ast.alias(name=name) for name in names], level=0)
     elif module is None and names:
         return ast.Import(names=[ast.alias(name=name) for name in names], level=0)
     else:
         return []
 
 
-def py_with(
-    item: ast.expr, body: List[ast.stmt], assignment: str | None = None
-) -> ast.With:
+def py_with(item: ast.expr, body: List[ast.stmt], assignment: str | None = None) -> ast.With:
     # noinspection PyTypeChecker
     """
     >>> render_ast(py_with(py_object("Bar"), [ast.Pass()]))
     'with Bar():\\n    pass'
     >>> render_ast(
-    ...   py_with(py_object("DAG", dag_id="foo").value, [py_object("Operator", task_id="foo")])
+    ...     py_with(
+    ...         py_object("DAG", dag_id="foo").value,
+    ...         [py_object("Operator", task_id="foo")],
+    ...     )
     ... )
     "with DAG(dag_id='foo'):\\n    Operator(task_id='foo')"
     >>> render_ast(
-    ...   py_with(py_object("DAG", dag_id="foo").value, [py_object("Operator", task_id="foo")], "dag")
+    ...     py_with(
+    ...         py_object("DAG", dag_id="foo").value,
+    ...         [py_object("Operator", task_id="foo")],
+    ...         "dag",
+    ...     )
     ... )
     "with DAG(dag_id='foo') as dag:\\n    Operator(task_id='foo')"
     """
@@ -142,7 +122,7 @@ def py_with(
 def py_function(c: Callable):
     """
     >>> def foo(a, b):
-    ...    print(a + b)
+    ...     print(a + b)
     >>> render_ast(py_function(foo))
     'def foo(a, b):\\n    print(a + b)'
     """

--- a/orbiter/file_types.py
+++ b/orbiter/file_types.py
@@ -184,8 +184,4 @@ class FileTypeYAML(FileType):
 if __name__ == "__main__":
     import doctest
 
-    doctest.testmod(
-        optionflags=doctest.ELLIPSIS
-        | doctest.NORMALIZE_WHITESPACE
-        | doctest.IGNORE_EXCEPTION_DETAIL
-    )
+    doctest.testmod(optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL)

--- a/orbiter/objects/__init__.py
+++ b/orbiter/objects/__init__.py
@@ -63,9 +63,7 @@ def conn_id(conn_id: str, prefix: str = "", conn_type: str = "generic") -> dict:
 
     Usage:
     ```python
-    OrbiterBashOperator(
-        **conn_id("my_conn_id")
-    )
+    OrbiterBashOperator(**conn_id("my_conn_id"))
     ```
     :param conn_id: The connection id
     :type conn_id: str
@@ -80,11 +78,7 @@ def conn_id(conn_id: str, prefix: str = "", conn_type: str = "generic") -> dict:
 
     return {
         f"{prefix + '_' if prefix else ''}conn_id": conn_id,
-        "orbiter_conns": {
-            OrbiterConnection(
-                conn_id=conn_id, **({"conn_type": conn_type} if conn_type else {})
-            )
-        },
+        "orbiter_conns": {OrbiterConnection(conn_id=conn_id, **({"conn_type": conn_type} if conn_type else {}))},
     }
 
 
@@ -93,9 +87,7 @@ def pool(name: str) -> dict:
 
     Usage:
     ```python
-    OrbiterBashOperator(
-        **pool("my_pool")
-    )
+    OrbiterBashOperator(**pool("my_pool"))
     ```
     :param name: The pool name
     :type name: str

--- a/orbiter/objects/callbacks/smtp.py
+++ b/orbiter/objects/callbacks/smtp.py
@@ -74,9 +74,7 @@ class OrbiterSmtpNotifierCallback(OrbiterCallback, extra="allow"):
     to: str | Iterable[str]
     from_email: str | None = None
     smtp_conn_id: str | None = "SMTP"
-    orbiter_conns: Set[OrbiterConnection] | None = {
-        OrbiterConnection(conn_id="SMTP", conn_type="smtp")
-    }
+    orbiter_conns: Set[OrbiterConnection] | None = {OrbiterConnection(conn_id="SMTP", conn_type="smtp")}
     subject: str | None = None
     html_content: str | None = None
     cc: str | Iterable[str] | None = None

--- a/orbiter/objects/callbacks/smtp.py
+++ b/orbiter/objects/callbacks/smtp.py
@@ -28,7 +28,7 @@ class OrbiterSmtpNotifierCallback(OrbiterCallback, extra="allow"):
 
     ```pycon
     >>> [_import] = OrbiterSmtpNotifierCallback(to="foo@test.com").imports; _import
-    OrbiterRequirements(names=[send_smtp_notification], package=apache-airflow-providers-smtp, module=airflow.providers.smtp.notifications.smtp, sys_package=None)
+    OrbiterRequirement(names=[send_smtp_notification], package=apache-airflow-providers-smtp, module=airflow.providers.smtp.notifications.smtp, sys_package=None)
 
     >>> OrbiterSmtpNotifierCallback(to="foo@test.com", from_email="bar@test.com", subject="Hello", html_content="World")
     send_smtp_notification(to='foo@test.com', from_email='bar@test.com', smtp_conn_id='SMTP', subject='Hello', html_content='World')

--- a/orbiter/objects/connection.py
+++ b/orbiter/objects/connection.py
@@ -35,7 +35,7 @@ class OrbiterConnection(BaseModel, AirflowSettingsRender, extra="allow"):
         from orbiter.objects import conn_id
 
         OrbiterTask(
-            ... ,
+            ...,
             **conn_id("my_conn_id", conn_type="mysql"),
         )
         ```
@@ -63,8 +63,4 @@ class OrbiterConnection(BaseModel, AirflowSettingsRender, extra="allow"):
         return hash(f"{self.model_dump_json()}")
 
     def __repr__(self):
-        return (
-            "OrbiterConnection("
-            + ", ".join(f"{k}={v}" for k, v in self.model_dump().items())
-            + ")"
-        )
+        return "OrbiterConnection(" + ", ".join(f"{k}={v}" for k, v in self.model_dump().items()) + ")"

--- a/orbiter/objects/dag.py
+++ b/orbiter/objects/dag.py
@@ -65,7 +65,7 @@ def _get_imports_recursively(
     ...     ]
     ... )
     ... # doctest: +ELLIPSIS
-    [OrbiterRequirements(...names=[bar]...names=[baz]...names=[foo]...names=[qux]...]
+    [OrbiterRequirement(...names=[bar]...names=[baz]...names=[foo]...names=[qux]...]
 
     """
     imports = set()

--- a/orbiter/objects/operators/bash.py
+++ b/orbiter/objects/operators/bash.py
@@ -45,8 +45,6 @@ class OrbiterBashOperator(OrbiterOperator):
     ]
     operator: str = "BashOperator"
     # noinspection Pydantic
-    render_attributes: RenderAttributes = OrbiterOperator.render_attributes + [
-        "bash_command"
-    ]
+    render_attributes: RenderAttributes = OrbiterOperator.render_attributes + ["bash_command"]
 
     bash_command: str

--- a/orbiter/objects/operators/python.py
+++ b/orbiter/objects/operators/python.py
@@ -28,6 +28,19 @@ class OrbiterPythonOperator(OrbiterOperator):
     foo_task = PythonOperator(task_id='foo', python_callable=foo)
 
     ```
+
+    You can utilize the `orbiter_includes` and `imports` to include additional Python code and imports (or subclass to default).
+    ```pycon
+    >>> from orbiter.objects.include import OrbiterInclude
+    >>> OrbiterPythonOperator(
+    ...     task_id="foo",
+    ...     orbiter_includes={OrbiterInclude(filepath="include/bar.py", contents="def baz(): pass")},
+    ...     imports=[OrbiterRequirement(module="include.bar", names=["baz"])],
+    ...     python_callable="baz"
+    ... )
+    foo_task = PythonOperator(task_id='foo', python_callable=baz)
+
+    ```
     :param task_id: The `task_id` for the operator
     :type task_id: str
     :param python_callable: The python function to execute
@@ -65,9 +78,17 @@ class OrbiterPythonOperator(OrbiterOperator):
         "op_kwargs",
     ]
 
-    python_callable: Callable
+    python_callable: Callable | str
     op_args: list | None = None
     op_kwargs: dict | None = None
 
     def _to_ast(self):
-        return [py_function(self.python_callable), super()._to_ast()]
+        if isinstance(self.python_callable, Callable):
+            return [py_function(self.python_callable), super()._to_ast()]
+        return super()._to_ast()
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod(optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL)

--- a/orbiter/objects/operators/smtp.py
+++ b/orbiter/objects/operators/smtp.py
@@ -75,6 +75,4 @@ class OrbiterEmailOperator(OrbiterOperator):
     html_content: str
     files: list | None = []
     conn_id: str | None = "SMTP"
-    orbiter_conns: Set[OrbiterConnection] | None = {
-        OrbiterConnection(conn_id="SMTP", conn_type="smtp")
-    }
+    orbiter_conns: Set[OrbiterConnection] | None = {OrbiterConnection(conn_id="SMTP", conn_type="smtp")}

--- a/orbiter/objects/pool.py
+++ b/orbiter/objects/pool.py
@@ -28,7 +28,7 @@ class OrbiterPool(BaseModel, AirflowSettingsRender, extra="forbid"):
         from orbiter.objects import pool
 
         OrbiterTask(
-            ... ,
+            ...,
             **pool("my_pool"),
         )
         ```

--- a/orbiter/objects/project.py
+++ b/orbiter/objects/project.py
@@ -66,7 +66,7 @@ class OrbiterProject:
     :type includes: Dict[str, OrbiterInclude]
     :param pools: A dictionary of [OrbiterPools][orbiter.objects.pool.OrbiterPool]
     :type pools: Dict[str, OrbiterPool]
-    :param requirements: A set of [OrbiterRequirements][orbiter.objects.requirement.OrbiterRequirement]
+    :param requirements: A set of [OrbiterRequirement][orbiter.objects.requirement.OrbiterRequirement]
     :type requirements: Set[OrbiterRequirement]
     :param variables: A dictionary of [OrbiterVariables][orbiter.objects.variable.OrbiterVariable]
     :type variables: Dict[str, OrbiterVariable]
@@ -107,8 +107,8 @@ class OrbiterProject:
 
     def __eq__(self, other) -> bool:
         return all(
-            [str(self.dags[d]) == str(other.dags[d]) for d in self.dags]
-            + [str(self.dags[d]) == str(other.dags[d]) for d in other.dags]
+            [str(self.dags[d]) == str(other.dags.get(d, "")) for d in self.dags]
+            + [str(self.dags.get(d, "")) == str(other.dags[d]) for d in other.dags]
             + [self.requirements == other.requirements]
             + [self.pools == other.pools]
             + [self.connections == other.connections]
@@ -171,7 +171,7 @@ class OrbiterProject:
     # noinspection t
     def add_dags(self, dags: OrbiterDAG | Iterable[OrbiterDAG]) -> "OrbiterProject":
         """Add [OrbiterDAGs][orbiter.objects.dag.OrbiterDAG]
-        (and any [OrbiterRequirements][orbiter.objects.requirement.OrbiterRequirement],
+        (and any [OrbiterRequirement][orbiter.objects.requirement.OrbiterRequirement],
         [OrbiterConns][orbiter.objects.connection.OrbiterConnection],
         [OrbiterVars][orbiter.objects.variable.OrbiterVariable],
         [OrbiterPools][orbiter.objects.pool.OrbiterPool],
@@ -214,12 +214,12 @@ class OrbiterProject:
         ... ))
         ... # doctest: +NORMALIZE_WHITESPACE
         OrbiterProject(dags=[foo],
-        requirements=[OrbiterRequirements(names=[DAG], package=apache-airflow, module=airflow, sys_package=None),
-        OrbiterRequirements(names=[BashOperator], package=apache-airflow, module=airflow.operators.bash, sys_package=None),
-        OrbiterRequirements(names=[send_smtp_notification], package=apache-airflow-providers-smtp, module=airflow.providers.smtp.notifications.smtp, sys_package=None),
-        OrbiterRequirements(names=[TaskGroup], package=apache-airflow, module=airflow.utils.task_group, sys_package=None),
-        OrbiterRequirements(names=[MultiCronTimetable], package=croniter, module=multi_cron_timetable, sys_package=None),
-        OrbiterRequirements(names=[DateTime,Timezone], package=pendulum, module=pendulum, sys_package=None)],
+        requirements=[OrbiterRequirement(names=[DAG], package=apache-airflow, module=airflow, sys_package=None),
+        OrbiterRequirement(names=[BashOperator], package=apache-airflow, module=airflow.operators.bash, sys_package=None),
+        OrbiterRequirement(names=[send_smtp_notification], package=apache-airflow-providers-smtp, module=airflow.providers.smtp.notifications.smtp, sys_package=None),
+        OrbiterRequirement(names=[TaskGroup], package=apache-airflow, module=airflow.utils.task_group, sys_package=None),
+        OrbiterRequirement(names=[MultiCronTimetable], package=croniter, module=multi_cron_timetable, sys_package=None),
+        OrbiterRequirement(names=[DateTime,Timezone], package=pendulum, module=pendulum, sys_package=None)],
         pools=['foo'],
         connections=['SMTP', 'foo'],
         variables=['foo'],
@@ -421,19 +421,19 @@ class OrbiterProject:
         return self
 
     def add_requirements(self, requirements: OrbiterRequirement | Iterable[OrbiterRequirement]) -> "OrbiterProject":
-        """Add [OrbiterRequirements][orbiter.objects.requirement.OrbiterRequirement] to the Project
+        """Add [OrbiterRequirement][orbiter.objects.requirement.OrbiterRequirement] to the Project
         or override an existing requirement with new properties
 
         ```pycon
         >>> OrbiterProject().add_requirements(
         ...    OrbiterRequirement(package="apache-airflow", names=['foo'], module='bar'),
         ... ).requirements
-        {OrbiterRequirements(names=[foo], package=apache-airflow, module=bar, sys_package=None)}
+        {OrbiterRequirement(names=[foo], package=apache-airflow, module=bar, sys_package=None)}
 
         >>> OrbiterProject().add_requirements(
         ...    [OrbiterRequirement(package="apache-airflow", names=['foo'], module='bar')],
         ... ).requirements
-        {OrbiterRequirements(names=[foo], package=apache-airflow, module=bar, sys_package=None)}
+        {OrbiterRequirement(names=[foo], package=apache-airflow, module=bar, sys_package=None)}
 
         ```
 
@@ -453,7 +453,7 @@ class OrbiterProject:
             pydantic_core._pydantic_core.ValidationError: ...
 
             ```
-        :param requirements: List of [OrbiterRequirements][orbiter.objects.requirement.OrbiterRequirement]
+        :param requirements: List of [OrbiterRequirement][orbiter.objects.requirement.OrbiterRequirement]
         :type requirements: List[OrbiterRequirement] | OrbiterRequirement
         :return: self
         :rtype: OrbiterProject

--- a/orbiter/objects/project.py
+++ b/orbiter/objects/project.py
@@ -554,6 +554,7 @@ class OrbiterProject:
             for include in self.includes.values():
                 include_path = output_dir / include.filepath
                 logger.info(f"Writing {include_path}")
+                include_path.parent.mkdir(parents=True, exist_ok=True)
                 include_path.write_text(include.render())
         else:
             logger.debug("No files to include")

--- a/orbiter/objects/project.py
+++ b/orbiter/objects/project.py
@@ -127,9 +127,7 @@ class OrbiterProject:
             f"env_vars={sorted(self.env_vars)})"
         )
 
-    def add_connections(
-        self, connections: OrbiterConnection | Iterable[OrbiterConnection]
-    ) -> "OrbiterProject":
+    def add_connections(self, connections: OrbiterConnection | Iterable[OrbiterConnection]) -> "OrbiterProject":
         """Add [`OrbiterConnections`][orbiter.objects.connection.OrbiterConnection] to the Project
         or override an existing connection with new properties
 
@@ -166,9 +164,7 @@ class OrbiterProject:
         :return: self
         :rtype: OrbiterProject
         """  # noqa: E501
-        for connection in (
-            [connections] if isinstance(connections, OrbiterConnection) else connections
-        ):
+        for connection in [connections] if isinstance(connections, OrbiterConnection) else connections:
             self.connections[connection.conn_id] = connection
         return self
 
@@ -201,8 +197,8 @@ class OrbiterProject:
         ...     orbiter_env_vars={OrbiterEnvVar(key="foo", value="bar")},
         ...     orbiter_includes={OrbiterInclude(filepath='foo.txt', contents="Hello, World!")},
         ...     schedule=OrbiterMultiCronTimetable(cron_defs=["0 */5 * * *", "0 */3 * * *"]),
-        ...     tasks={'foo': OrbiterTaskGroup(task_group_id="foo",
-        ...         tasks=[OrbiterBashOperator(
+        ...     ).add_tasks(
+        ...         OrbiterTaskGroup(task_group_id="foo").add_tasks(OrbiterBashOperator(
         ...             task_id='foo', bash_command='echo "Hello, World!"',
         ...             orbiter_pool=OrbiterPool(name='foo', slots=1),
         ...             orbiter_vars={OrbiterVariable(key='foo', value='bar')},
@@ -213,8 +209,8 @@ class OrbiterProject:
         ...                 smtp_conn_id="SMTP",
         ...                 orbiter_conns={OrbiterConnection(conn_id="SMTP", conn_type="smtp")}
         ...             )
-        ...         )]
-        ...     )}
+        ...         )
+        ...     )
         ... ))
         ... # doctest: +NORMALIZE_WHITESPACE
         OrbiterProject(dags=[foo],
@@ -256,13 +252,7 @@ class OrbiterProject:
 
         # noinspection t
         def _add_recursively(
-            things: Iterable[
-                OrbiterOperator
-                | OrbiterTaskGroup
-                | OrbiterCallback
-                | OrbiterTimetable
-                | OrbiterDAG
-            ],
+            things: Iterable[OrbiterOperator | OrbiterTaskGroup | OrbiterCallback | OrbiterTimetable | OrbiterDAG],
         ):
             for thing in things:
                 if isinstance(thing, str):
@@ -273,24 +263,19 @@ class OrbiterProject:
                     self.add_connections(conns)
                 if hasattr(thing, "orbiter_vars") and (variables := thing.orbiter_vars):
                     self.add_variables(variables)
-                if hasattr(thing, "orbiter_env_vars") and (
-                    env_vars := thing.orbiter_env_vars
-                ):
+                if hasattr(thing, "orbiter_env_vars") and (env_vars := thing.orbiter_env_vars):
                     self.add_env_vars(env_vars)
-                if hasattr(thing, "orbiter_includes") and (
-                    includes := thing.orbiter_includes
-                ):
+                if hasattr(thing, "orbiter_includes") and (includes := thing.orbiter_includes):
                     self.add_includes(includes)
                 if hasattr(thing, "imports") and (imports := thing.imports):
                     self.add_requirements(imports)
                 if isinstance(thing, OrbiterTaskGroup) and (tasks := thing.tasks):
-                    _add_recursively(tasks)
+                    _add_recursively(tasks.values())
                 if hasattr(thing, "__dict__") or hasattr(thing, "model_extra"):
                     # If it's a pydantic model or dict, check its properties for more things to add
                     _add_recursively(
                         (
-                            (getattr(thing, "__dict__", {}) or dict())
-                            | (getattr(thing, "model_extra", {}) or dict())
+                            (getattr(thing, "__dict__", {}) or dict()) | (getattr(thing, "model_extra", {}) or dict())
                         ).values()
                     )
 
@@ -310,9 +295,7 @@ class OrbiterProject:
             _add_recursively([dag])
         return self
 
-    def add_env_vars(
-        self, env_vars: OrbiterEnvVar | Iterable[OrbiterEnvVar]
-    ) -> "OrbiterProject":
+    def add_env_vars(self, env_vars: OrbiterEnvVar | Iterable[OrbiterEnvVar]) -> "OrbiterProject":
         """
         Add [OrbiterEnvVars][orbiter.objects.env_var.OrbiterEnvVar] to the Project
         or override an existing env var with new properties
@@ -353,9 +336,7 @@ class OrbiterProject:
             self.env_vars[env_var.key] = env_var
         return self
 
-    def add_includes(
-        self, includes: OrbiterInclude | Iterable[OrbiterInclude]
-    ) -> "OrbiterProject":
+    def add_includes(self, includes: OrbiterInclude | Iterable[OrbiterInclude]) -> "OrbiterProject":
         """Add [OrbiterIncludes][orbiter.objects.include.OrbiterInclude] to the Project
         or override an existing [OrbiterInclude][orbiter.objects.include.OrbiterInclude] with new properties
 
@@ -439,9 +420,7 @@ class OrbiterProject:
                 self.pools[pool.name] = pool
         return self
 
-    def add_requirements(
-        self, requirements: OrbiterRequirement | Iterable[OrbiterRequirement]
-    ) -> "OrbiterProject":
+    def add_requirements(self, requirements: OrbiterRequirement | Iterable[OrbiterRequirement]) -> "OrbiterProject":
         """Add [OrbiterRequirements][orbiter.objects.requirement.OrbiterRequirement] to the Project
         or override an existing requirement with new properties
 
@@ -479,17 +458,11 @@ class OrbiterProject:
         :return: self
         :rtype: OrbiterProject
         """
-        for requirement in (
-            [requirements]
-            if isinstance(requirements, OrbiterRequirement)
-            else requirements
-        ):
+        for requirement in [requirements] if isinstance(requirements, OrbiterRequirement) else requirements:
             self.requirements.add(requirement)
         return self
 
-    def add_variables(
-        self, variables: OrbiterVariable | Iterable[OrbiterVariable]
-    ) -> "OrbiterProject":
+    def add_variables(self, variables: OrbiterVariable | Iterable[OrbiterVariable]) -> "OrbiterProject":
         """Add [OrbiterVariables][orbiter.objects.variable.OrbiterVariable] to the Project
         or override an existing variable with new properties
 
@@ -523,9 +496,7 @@ class OrbiterProject:
         :return: self
         :rtype: OrbiterProject
         """
-        for variable in (
-            [variables] if isinstance(variables, OrbiterVariable) else variables
-        ):
+        for variable in [variables] if isinstance(variables, OrbiterVariable) else variables:
             self.variables[variable.key] = variable
         return self
 
@@ -549,11 +520,7 @@ class OrbiterProject:
         if len([1 for r in self.requirements if r.package]):
             requirements = output_dir / "requirements.txt"
             logger.info(f"Writing {requirements}")
-            requirements.write_text(
-                "\n".join(
-                    sorted(set(r.package for r in self.requirements if r.package))
-                )
-            )
+            requirements.write_text("\n".join(sorted(set(r.package for r in self.requirements if r.package))))
         else:
             logger.debug("No python packages to write, skipping requirements.txt...")
 
@@ -561,13 +528,7 @@ class OrbiterProject:
         if len([1 for r in self.requirements if r.sys_package]):
             packages = output_dir / "packages.txt"
             logger.info(f"Writing {packages}")
-            packages.write_text(
-                "\n".join(
-                    sorted(
-                        set(r.sys_package for r in self.requirements if r.sys_package)
-                    )
-                )
-            )
+            packages.write_text("\n".join(sorted(set(r.sys_package for r in self.requirements if r.sys_package))))
         else:
             logger.debug("No system packages to write, skipping packages.txt...")
 
@@ -579,21 +540,14 @@ class OrbiterProject:
                 {
                     "airflow": {
                         "pools": [pool.render() for pool in self.pools.values()],
-                        "variables": [
-                            variable.render() for variable in self.variables.values()
-                        ],
-                        "connections": [
-                            connection.render()
-                            for connection in self.connections.values()
-                        ],
+                        "variables": [variable.render() for variable in self.variables.values()],
+                        "connections": [connection.render() for connection in self.connections.values()],
                     }
                 },
                 airflow_settings.open("w"),
             )
         else:
-            logger.debug(
-                "No Pools, Variables, or Connections to write. Skipping airflow_settings.yaml..."
-            )
+            logger.debug("No Pools, Variables, or Connections to write. Skipping airflow_settings.yaml...")
 
         # /include
         if len(self.includes):
@@ -613,9 +567,7 @@ class OrbiterProject:
             logger.debug("No entries for .env")
 
     @validate_call
-    def analyze(
-        self, output_fmt: Literal["json", "csv", "md"] = "md", output_file=None
-    ):
+    def analyze(self, output_fmt: Literal["json", "csv", "md"] = "md", output_file=None):
         """Print an analysis of the project to the console.
 
         !!! tip
@@ -655,9 +607,7 @@ class OrbiterProject:
 
         def get_task_type(task):
             match = _task_type.match(getattr(task, "doc_md", None) or "")
-            match_or_task_type = (
-                match.groupdict().get("task_type") if match else None
-            ) or type(task).__name__
+            match_or_task_type = (match.groupdict().get("task_type") if match else None) or type(task).__name__
             return match_or_task_type
 
         dag_analysis = [
@@ -736,8 +686,4 @@ OrbiterProject.add_variables = validate_call()(OrbiterProject.add_variables)
 if __name__ == "__main__":
     import doctest
 
-    doctest.testmod(
-        optionflags=doctest.ELLIPSIS
-        | doctest.NORMALIZE_WHITESPACE
-        | doctest.IGNORE_EXCEPTION_DETAIL
-    )
+    doctest.testmod(optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL)

--- a/orbiter/objects/requirement.py
+++ b/orbiter/objects/requirement.py
@@ -64,9 +64,7 @@ class OrbiterRequirement(OrbiterASTBase, BaseModel, extra="forbid"):
         )
 
     def __hash__(self):
-        return hash(
-            f"{self.package}{self.module}{''.join(self.names)}{self.sys_package}"
-        )
+        return hash(f"{self.package}{self.module}{''.join(self.names)}{self.sys_package}")
 
     def _to_ast(self) -> ast.stmt | ast.Module:
         """Render to `from ... import`

--- a/orbiter/objects/requirement.py
+++ b/orbiter/objects/requirement.py
@@ -56,7 +56,7 @@ class OrbiterRequirement(OrbiterASTBase, BaseModel, extra="forbid"):
 
     def __repr__(self):
         return (
-            f"OrbiterRequirements("
+            f"OrbiterRequirement("
             f"names=[{','.join(sorted(self.names))}], "
             f"package={self.package}, "
             f"module={self.module}, "

--- a/orbiter/objects/task.py
+++ b/orbiter/objects/task.py
@@ -232,7 +232,11 @@ class OrbiterOperator(OrbiterASTBase, OrbiterBase, ABC, extra="allow"):
     def _to_ast(self) -> ast.stmt:
         def prop(k):
             attr = getattr(self, k, None) or getattr(self.model_extra, k, None)
-            return ast.Name(id=attr.__name__) if isinstance(attr, Callable) else attr
+            if isinstance(attr, Callable):
+                return ast.Name(id=attr.__name__)
+            elif "_callable" in k and isinstance(attr, str):
+                return ast.Name(id=attr)
+            return attr
 
         # foo = Bar(x=x,y=y, z=z)
         return py_assigned_object(

--- a/orbiter/objects/task.py
+++ b/orbiter/objects/task.py
@@ -72,9 +72,7 @@ def task_add_downstream(
     if isinstance(task_id, OrbiterTaskDependency):
         task_dependency = task_id
         if task_dependency.task_id != self.task_id:
-            raise ValueError(
-                f"task_dependency={task_dependency} has a different task_id than {self.task_id}"
-            )
+            raise ValueError(f"task_dependency={task_dependency} has a different task_id than {self.task_id}")
         # do normal parsing logic, but with these downstream items
         task_id = task_dependency.downstream
 
@@ -213,9 +211,7 @@ class OrbiterOperator(OrbiterASTBase, OrbiterBase, ABC, extra="allow"):
     --8<-- [end:mermaid-op-props]
     """
 
-    def add_downstream(
-        self, task_id: str | List[str] | OrbiterTaskDependency
-    ) -> "OrbiterOperator":
+    def add_downstream(self, task_id: str | List[str] | OrbiterTaskDependency) -> "OrbiterOperator":
         return task_add_downstream(self, task_id)
 
     def _downstream_to_ast(self) -> List[ast.stmt]:
@@ -308,28 +304,17 @@ class OrbiterTask(OrbiterOperator, extra="allow"):
             if "operator" in name.lower() or "sensor" in name.lower()
         ]
         if len(operator_names) != 1:
-            raise ValueError(
-                f"Expected exactly one operator name, got {operator_names}"
-            )
+            raise ValueError(f"Expected exactly one operator name, got {operator_names}")
         [operator] = operator_names
 
         self_as_ast = py_assigned_object(
             to_task_id(self.task_id, ORBITER_TASK_SUFFIX),
             operator,
-            **{
-                k: prop(k)
-                for k in ["task_id"] + sorted(self.__pydantic_extra__.keys())
-                if k and getattr(self, k)
-            },
+            **{k: prop(k) for k in ["task_id"] + sorted(self.__pydantic_extra__.keys()) if k and getattr(self, k)},
         )
-        callable_props = [
-            k
-            for k in self.__pydantic_extra__.keys()
-            if isinstance(getattr(self, k), Callable)
-        ]
+        callable_props = [k for k in self.__pydantic_extra__.keys() if isinstance(getattr(self, k), Callable)]
         return (
-            [py_function(getattr(self, prop)) for prop in callable_props]
-            + [self_as_ast]
+            [py_function(getattr(self, prop)) for prop in callable_props] + [self_as_ast]
             if len(callable_props)
             else self_as_ast
         )
@@ -354,8 +339,4 @@ def to_task_id(task_id: str, assignment_suffix: str = "") -> str:
     :type assignment_suffix: str
     """
     task_id = clean_value(task_id)
-    return task_id + (
-        assignment_suffix
-        if task_id[-len(assignment_suffix) :] != assignment_suffix
-        else ""
-    )
+    return task_id + (assignment_suffix if task_id[-len(assignment_suffix) :] != assignment_suffix else "")

--- a/orbiter/objects/task_group.py
+++ b/orbiter/objects/task_group.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import ast
 from abc import ABC
-from typing import List, Any, Set
+from typing import List, Any, Set, Dict, Union
 
-from pydantic import field_validator
+from pydantic import field_validator, validate_call
 
 from orbiter.config import ORBITER_TASK_SUFFIX
 from orbiter.ast_helper import (
@@ -40,31 +40,30 @@ class OrbiterTaskGroup(OrbiterASTBase, OrbiterBase, ABC, extra="forbid"):
     ```pycon
     >>> from orbiter.objects.operators.bash import OrbiterBashOperator
     >>> from orbiter.ast_helper import render_ast
-    >>> OrbiterTaskGroup(task_group_id="foo", tasks=[
+    >>> OrbiterTaskGroup(task_group_id="foo").add_tasks([
     ...   OrbiterBashOperator(task_id="b", bash_command="b"),
     ...   OrbiterBashOperator(task_id="a", bash_command="a").add_downstream("b"),
-    ... ], downstream={"c"})
+    ... ]).add_downstream("c")
     with TaskGroup(group_id='foo') as foo:
         b_task = BashOperator(task_id='b', bash_command='b')
         a_task = BashOperator(task_id='a', bash_command='a')
         a_task >> b_task
 
-    >>> render_ast(OrbiterTaskGroup(task_group_id="foo", tasks=[], downstream={"c"})._downstream_to_ast())
+    >>> render_ast(OrbiterTaskGroup(task_group_id="foo", downstream={"c"})._downstream_to_ast())
     'foo >> c_task'
 
     ```
-
     :param task_group_id: The id of the TaskGroup
     :type task_group_id: str
     :param tasks: The tasks in the TaskGroup
-    :type tasks: List[OrbiterOperator | OrbiterTaskGroup]
+    :type tasks: Dict[str, OrbiterOperator | OrbiterTaskGroup]
     :param **OrbiterBase: [OrbiterBase][orbiter.objects.OrbiterBase] inherited properties
     """
 
     __mermaid__ = """
        --8<-- [start:mermaid-op-props]
     task_group_id: str
-    tasks: List[OrbiterOperator | OrbiterTaskGroup]
+    tasks: Dict[str, OrbiterOperator | OrbiterTaskGroup]
     add_downstream(str | List[str] | OrbiterTaskDependency)
     --8<-- [end:mermaid-op-props]
     """
@@ -77,7 +76,7 @@ class OrbiterTaskGroup(OrbiterASTBase, OrbiterBase, ABC, extra="forbid"):
         )
     ]
     task_group_id: TaskId
-    tasks: List[Any]
+    tasks: Dict[str, Union[OrbiterOperator, OrbiterTaskGroup]] = dict()
     downstream: Set[str] = set()
 
     @property
@@ -94,20 +93,18 @@ class OrbiterTaskGroup(OrbiterASTBase, OrbiterBase, ABC, extra="forbid"):
     @field_validator("tasks")
     @classmethod
     def ensure_tasks(cls, tasks: Any):
-        if any(
-            not (
-                issubclass(type(i), OrbiterOperator) or isinstance(i, OrbiterTaskGroup)
-            )
-            for i in tasks
-        ):
+        if any(not (issubclass(type(i), OrbiterOperator) or isinstance(i, OrbiterTaskGroup)) for i in tasks.values()):
             raise TypeError(
                 f"At least one item in tasks={tasks} is not a subclass of OrbiterOperator nor an OrbiterTaskGroup"
             )
         return tasks
 
-    def add_downstream(
-        self, task_id: str | List[str] | OrbiterTaskDependency
-    ) -> "OrbiterTaskGroup":
+    def add_tasks(self, tasks):
+        from orbiter.objects.dag import _add_tasks
+
+        return _add_tasks(self, tasks)
+
+    def add_downstream(self, task_id: str | List[str] | OrbiterTaskDependency) -> "OrbiterTaskGroup":
         return task_add_downstream(self, task_id)
 
     def _downstream_to_ast(self):
@@ -115,9 +112,7 @@ class OrbiterTaskGroup(OrbiterASTBase, OrbiterBase, ABC, extra="forbid"):
             return
         elif len(self.downstream) == 1:
             (t,) = tuple(self.downstream)
-            return py_bitshift(
-                to_task_id(self.task_id), to_task_id(t, ORBITER_TASK_SUFFIX)
-            )
+            return py_bitshift(to_task_id(self.task_id), to_task_id(t, ORBITER_TASK_SUFFIX))
         else:
             return py_bitshift(
                 to_task_id(self.task_id),
@@ -128,11 +123,11 @@ class OrbiterTaskGroup(OrbiterASTBase, OrbiterBase, ABC, extra="forbid"):
         # noinspection PyProtectedMember
         return py_with(
             py_object("TaskGroup", group_id=self.task_group_id).value,
-            [operator._to_ast() for operator in self.tasks]
-            + [
-                downstream
-                for operator in self.tasks
-                if (downstream := operator._downstream_to_ast())
-            ],
+            [operator._to_ast() for operator in self.tasks.values()]
+            + [downstream for operator in self.tasks.values() if (downstream := operator._downstream_to_ast())],
             self.task_group_id,
         )
+
+
+# https://github.com/pydantic/pydantic/issues/8790
+OrbiterTaskGroup.add_tasks = validate_call()(OrbiterTaskGroup.add_tasks)

--- a/orbiter/objects/task_group.py
+++ b/orbiter/objects/task_group.py
@@ -120,6 +120,22 @@ class OrbiterTaskGroup(OrbiterASTBase, OrbiterBase, ABC, extra="forbid"):
             )
 
     def _to_ast(self) -> ast.stmt:
+        """
+        ```pycon
+        >>> from orbiter.objects.operators.bash import OrbiterBashOperator
+        >>> from orbiter.ast_helper import render_ast
+        >>> # noinspection PyProtectedMember
+        ... OrbiterTaskGroup(task_group_id="foo").add_tasks([
+        ...     OrbiterBashOperator(task_id="a", bash_command="a").add_downstream("b"),
+        ...     OrbiterBashOperator(task_id="b", bash_command="b")
+        ... ])  # doctest: +NORMALIZE_WHITESPACE
+        with TaskGroup(group_id='foo') as foo:
+            a_task = BashOperator(task_id='a', bash_command='a')
+            b_task = BashOperator(task_id='b', bash_command='b')
+            a_task >> b_task
+
+        ```
+        """
         # noinspection PyProtectedMember
         return py_with(
             py_object("TaskGroup", group_id=self.task_group_id).value,
@@ -131,3 +147,8 @@ class OrbiterTaskGroup(OrbiterASTBase, OrbiterBase, ABC, extra="forbid"):
 
 # https://github.com/pydantic/pydantic/issues/8790
 OrbiterTaskGroup.add_tasks = validate_call()(OrbiterTaskGroup.add_tasks)
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod(optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL)

--- a/orbiter/objects/timetables/__init__.py
+++ b/orbiter/objects/timetables/__init__.py
@@ -21,7 +21,7 @@ class OrbiterTimetable(OrbiterBase, OrbiterASTBase, BaseModel, extra="allow"):
 
     __mermaid__ = """
     --8<-- [start:mermaid-props]
-    imports: List[OrbiterRequirements]
+    imports: List[OrbiterRequirement]
     orbiter_includes: Set[OrbiterIncludes]
     **kwargs: dict
     --8<-- [end:mermaid-props]

--- a/orbiter/objects/timetables/__init__.py
+++ b/orbiter/objects/timetables/__init__.py
@@ -31,24 +31,13 @@ class OrbiterTimetable(OrbiterBase, OrbiterASTBase, BaseModel, extra="allow"):
 
     def _to_ast(self) -> ast.stmt | ast.Module:
         # Figure out which timetable we are talking about
-        timetable_names = [
-            name
-            for _import in self.imports
-            for name in _import.names
-            if "timetable" in name.lower()
-        ]
+        timetable_names = [name for _import in self.imports for name in _import.names if "timetable" in name.lower()]
         if len(timetable_names) != 1:
-            raise ValueError(
-                f"Expected exactly one Timetable name, got {timetable_names}"
-            )
+            raise ValueError(f"Expected exactly one Timetable name, got {timetable_names}")
         [timetable] = timetable_names
 
         return py_object(
             timetable,
-            **{
-                k: getattr(self, k)
-                for k in self.render_attributes
-                if k and getattr(self, k)
-            },
+            **{k: getattr(self, k) for k in self.render_attributes if k and getattr(self, k)},
             **{k: getattr(self, k) for k in (self.model_extra.keys() or [])},
         )

--- a/orbiter/objects/timetables/multi_cron_timetable.py
+++ b/orbiter/objects/timetables/multi_cron_timetable.py
@@ -242,9 +242,7 @@ class OrbiterMultiCronTimetable(OrbiterTimetable):
         )
     ]
     orbiter_includes: Set["OrbiterInclude"] = {
-        OrbiterInclude(
-            filepath="plugins/multi_cron_timetable.py", contents=TIMETABLE_CONTENTS
-        )
+        OrbiterInclude(filepath="plugins/multi_cron_timetable.py", contents=TIMETABLE_CONTENTS)
     }
     render_attributes: RenderAttributes = [
         "cron_defs",

--- a/orbiter/rules/__init__.py
+++ b/orbiter/rules/__init__.py
@@ -334,7 +334,7 @@ def cannot_map_rule(val: dict) -> OrbiterOperator | None:
     )
 
 
-EMPTY_RULE = Rule(rule=lambda _: None, priority=0)
+EMPTY_RULE = Rule(rule=lambda val: None, priority=0)
 """Empty rule, for testing"""
 
 

--- a/orbiter/rules/__init__.py
+++ b/orbiter/rules/__init__.py
@@ -83,15 +83,7 @@ def trim_dict(v):
 
 def rule(
     func=None, *, priority=None
-) -> (
-    Rule
-    | "DAGFilterRule"
-    | "DAGRule"
-    | "TaskFilterRule"
-    | "TaskRule"
-    | "TaskDependencyRule"
-    | "PostProcessingRule"
-):
+) -> Rule | "DAGFilterRule" | "DAGRule" | "TaskFilterRule" | "TaskRule" | "TaskDependencyRule" | "PostProcessingRule":
     if func is None:
         return functools.partial(rule, priority=priority)
 
@@ -210,7 +202,7 @@ class DAGRule(Rule):
     ```python
     @dag_rule
     def foo(val: dict) -> OrbiterDAG | None:
-        if 'id' in val:
+        if "id" in val:
             return OrbiterDAG(dag_id=val["id"], file_path=f"{val["id"]}.py")
         else:
             return None
@@ -242,6 +234,7 @@ class TaskFilterRule(Rule):
     :return: A list of dictionaries of possible tasks or `None`
     :rtype: List[dict] | None
     """
+
     rule: Callable[[dict], Collection[dict] | None]
 
 
@@ -255,8 +248,10 @@ class TaskRule(Rule):
     ```python
     @task_rule
     def foo(val: dict) -> OrbiterOperator | OrbiterTaskGroup:
-        if 'id' in val and 'command' in val:
-            return OrbiterBashOperator(task_id=val['id'], bash_command=val['command'])
+        if "id" in val and "command" in val:
+            return OrbiterBashOperator(
+                task_id=val["id"], bash_command=val["command"]
+            )
         else:
             return None
     ```
@@ -267,6 +262,7 @@ class TaskRule(Rule):
         or [`OrbiterTaskGroup`][orbiter.objects.task_group.OrbiterTaskGroup] or `None`
     :rtype: OrbiterOperator | OrbiterTaskGroup | None
     """
+
     rule: Callable[[dict], OrbiterOperator | OrbiterTaskGroup | None]
 
 
@@ -291,6 +287,7 @@ class TaskDependencyRule(Rule):
     :return: A list of [`OrbiterTaskDependency`][orbiter.objects.task.OrbiterTaskDependency] or `None`
     :rtype: List[OrbiterTaskDependency] | None
     """
+
     rule: Callable[[OrbiterDAG], List[OrbiterTaskDependency] | None]
 
 
@@ -315,6 +312,7 @@ class PostProcessingRule(Rule):
     :return: `None`
     :rtype: None
     """
+
     rule: Callable[[OrbiterProject], None]
 
 
@@ -343,8 +341,4 @@ EMPTY_RULE = Rule(rule=lambda _: None, priority=0)
 if __name__ == "__main__":
     import doctest
 
-    doctest.testmod(
-        optionflags=doctest.ELLIPSIS
-        | doctest.NORMALIZE_WHITESPACE
-        | doctest.IGNORE_EXCEPTION_DETAIL
-    )
+    doctest.testmod(optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,12 +128,12 @@ skips = [
     "B604",  # subprocess shell=True - using intentionally
 ]
 
-[tool.black]
-# https://github.com/psf/black
-color = true
-
 [tool.ruff]
 line-length = 120
+
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = 80
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,7 @@ from pathlib import Path
 import orbiter
 import pytest
 
-manual_tests = pytest.mark.skipif(
-    not bool(os.getenv("MANUAL_TESTS")), reason="requires env setup"
-)
+manual_tests = pytest.mark.skipif(not bool(os.getenv("MANUAL_TESTS")), reason="requires env setup")
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -8,8 +8,5 @@ def test_integration():
 
     output = run("just docker-run-binary", shell=True, capture_output=True, text=True)
     assert "Available Origins" in output.stdout
-    assert (
-        "Adding local .pyz files ['/data/orbiter_community_translations.pyz'] to sys.path"
-        in output.stdout
-    )
+    assert "Adding local .pyz files ['/data/orbiter_community_translations.pyz'] to sys.path" in output.stdout
     assert "Finding files with extension=['.xml'] in /data/workflow" in output.stdout

--- a/tests/orbiter/objects/dag_test.py
+++ b/tests/orbiter/objects/dag_test.py
@@ -23,9 +23,7 @@ def test_dag_render():
     # noinspection PyProtectedMember
     actual = render_ast(
         OrbiterDAG(dag_id="dag_id", file_path="")
-        .add_tasks(
-            OrbiterBashOperator(task_id="task_id", bash_command="echo 'hello world'")
-        )
+        .add_tasks(OrbiterBashOperator(task_id="task_id", bash_command="echo 'hello world'"))
         ._to_ast()
     )
     assert actual == expected_basic_dag
@@ -36,10 +34,7 @@ def test_dag_render_task_group():
     actual = render_ast(
         OrbiterDAG(dag_id="dag_id", file_path="")
         .add_tasks(
-            OrbiterTaskGroup(
-                task_group_id="foo",
-                tasks=[OrbiterBashOperator(task_id="bar", bash_command="bar")],
-            )
+            OrbiterTaskGroup(task_group_id="foo").add_tasks(OrbiterBashOperator(task_id="bar", bash_command="bar"))
         )
         ._to_ast()
     )

--- a/tests/orbiter/objects/project_test.py
+++ b/tests/orbiter/objects/project_test.py
@@ -17,9 +17,7 @@ def test_project_render(tmpdir):
     # noinspection PyArgumentList
     project = OrbiterProject().add_dags(
         dags=[
-            OrbiterDAG(
-                dag_id="foo", file_path="foo.py", schedule=None, doc_md="foo"
-            ).add_tasks(
+            OrbiterDAG(dag_id="foo", file_path="foo.py", schedule=None, doc_md="foo").add_tasks(
                 tasks=[
                     OrbiterTask(
                         task_id="foo",
@@ -27,14 +25,10 @@ def test_project_render(tmpdir):
                         pool="foo",
                         pool_slots=1,
                         trigger_rule="one_success",
-                        orbiter_pool=OrbiterPool(
-                            name="foo", description="foo", slots=1
-                        ),
+                        orbiter_pool=OrbiterPool(name="foo", description="foo", slots=1),
                         orbiter_vars={OrbiterVariable(key="foo", value="bar")},
                         orbiter_env_vars={OrbiterEnvVar(key="foo", value="bar")},
-                        orbiter_conns={
-                            OrbiterConnection(conn_id="foo", host="bar", password="baz")
-                        },
+                        orbiter_conns={OrbiterConnection(conn_id="foo", host="bar", password="baz")},
                         orbiter_kwargs={"SOME_INPUT": "FOOBAR"},
                         imports=[
                             OrbiterRequirement(
@@ -71,9 +65,7 @@ def test_project_render(tmpdir):
                         "conn_type": "generic",
                     }
                 ],
-                "pools": [
-                    {"pool_description": "foo", "pool_name": "foo", "pool_slot": 1}
-                ],
+                "pools": [{"pool_description": "foo", "pool_name": "foo", "pool_slot": 1}],
                 "variables": [{"variable_name": "foo", "variable_value": "bar"}],
             }
         }

--- a/tests/orbiter/rules/rulesets_test.py
+++ b/tests/orbiter/rules/rulesets_test.py
@@ -1,5 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
 from orbiter.file_types import FileTypeYAML
-from orbiter.rules.rulesets import TranslationRuleset, EMPTY_RULESET
+from orbiter.objects.dag import OrbiterDAG
+from orbiter.objects.operators.empty import OrbiterEmptyOperator
+from orbiter.objects.project import OrbiterProject
+from orbiter.objects.task import OrbiterOperator, OrbiterTaskDependency
+from orbiter.rules import dag_rule, dag_filter_rule, task_filter_rule, task_rule, task_dependency_rule
+from orbiter.rules.rulesets import TranslationRuleset, EMPTY_RULESET, translate
 
 
 def test_loads(project_root):
@@ -43,3 +53,67 @@ def test__get_files_with_extension(project_root):
         ),
     ]
     assert sorted(list(actual)) == sorted(expected)
+
+
+def test_translate():
+    expected = OrbiterProject().add_dags(
+        OrbiterDAG(dag_id="dag_a", file_path=Path("xyz.yaml")).add_tasks(
+            [OrbiterEmptyOperator(task_id="task_a").add_downstream("task_b"), OrbiterEmptyOperator(task_id="task_b")]
+        )
+    )
+
+    def test_file_generator(_, __):
+        yield (
+            Path("xyz.yaml"),
+            {
+                "dags": [
+                    {
+                        "dag_id": "dag_a",
+                        "tasks": [
+                            {"task_id": "task_a", "to": "task_b"},
+                            {"task_id": "task_b"},
+                        ],
+                    }
+                ]
+            },
+        )
+
+    @dag_filter_rule
+    def test_dag_filter_rule(val: dict) -> list[dict]:
+        return val.get("dags", [])
+
+    @dag_rule
+    def test_dag_rule(val: dict) -> OrbiterDAG:
+        return OrbiterDAG(dag_id=val["dag_id"], file_path=val["__file"])
+
+    @task_filter_rule
+    def test_task_filter_rule(val: dict) -> list[dict]:
+        return val.get("tasks", [])
+
+    @task_rule
+    def test_task_rule(val: dict) -> OrbiterOperator | None:
+        return OrbiterEmptyOperator(task_id=val.get("task_id"))
+
+    @task_dependency_rule
+    def test_task_dependency_rule(val: OrbiterDAG) -> List[OrbiterTaskDependency]:
+        return [
+            OrbiterTaskDependency(task_id=task["task_id"], downstream=to)
+            for task in val.orbiter_kwargs["val"].get("tasks", [])
+            if (to := task.get("to"))
+        ]
+
+    test_ruleset = TranslationRuleset(
+        file_type={FileTypeYAML},
+        dag_filter_ruleset={"ruleset": [test_dag_filter_rule]},
+        dag_ruleset={"ruleset": [test_dag_rule]},
+        task_filter_ruleset={"ruleset": [test_task_filter_rule]},
+        task_ruleset={"ruleset": [test_task_rule]},
+        task_dependency_ruleset={"ruleset": [test_task_dependency_rule]},
+        post_processing_ruleset=EMPTY_RULESET,
+        translate_fn=translate,
+    )
+    TranslationRuleset.get_files_with_extension = test_file_generator
+    actual = test_ruleset.translate_fn(translation_ruleset=test_ruleset, input_dir=Path("."))
+    assert actual == expected
+    assert actual.dags["dag_a"].tasks == expected.dags["dag_a"].tasks
+    assert actual.dags["dag_a"].tasks["task_a"].downstream == expected.dags["dag_a"].tasks["task_a"].downstream

--- a/tests/orbiter/rules/rulesets_test.py
+++ b/tests/orbiter/rules/rulesets_test.py
@@ -30,13 +30,11 @@ def test__get_files_with_extension(project_root):
     )
     expected = [
         (
-            project_root
-            / "tests/resources/test_get_files_with_extension/foo/bar/three.yaml",
+            project_root / "tests/resources/test_get_files_with_extension/foo/bar/three.yaml",
             {"three": "baz"},
         ),
         (
-            project_root
-            / "tests/resources/test_get_files_with_extension/foo/bar/two.yml",
+            project_root / "tests/resources/test_get_files_with_extension/foo/bar/two.yml",
             {"two": "bar"},
         ),
         (


### PR DESCRIPTION
- cicd: rm black, use only ruff
- feat: modify `task_group.tasks` to `dict[str, task]`, like `OrbiterDAG`
- feat: add task dependencies for nested tasks
- fix: have includes create parent folder structure if needed
- fix: allow python callable to be a string reference or a callable (and the callable gets inlined)
