### PR TITLE
`orbiter document` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ workflow
 *.pyz
 orbiter-*
 .python-version
+translation_ruleset.html

--- a/justfile
+++ b/justfile
@@ -101,7 +101,7 @@ docker-run-binary REPO='orbiter-community-translations'  DEMO="https://raw.githu
     cat <<"EOF" | docker run --platform {{PLATFORM}} -v `pwd`:/data -w /data -i ubuntu /bin/bash
     echo "[SETUP]" && \
     echo "setting up certificates for https" && \
-    apt update && apt install -y ca-certificates && update-ca-certificates --fresh && \
+    apt update && apt install -y curl ca-certificates && update-ca-certificates --fresh && \
     echo "sourcing .env" && \
     set -a && source .env && set +a && \
     chmod +x ./orbiter-linux-x86_64 && \
@@ -115,9 +115,9 @@ docker-run-binary REPO='orbiter-community-translations'  DEMO="https://raw.githu
     echo "[ORBITER INSTALL]" && \
     LOG_LEVEL=DEBUG ./orbiter-linux-x86_64 install --repo={{REPO}} && \
     echo "[ORBITER TRANSLATE]" && \
-    LOG_LEVEL=DEBUG ./orbiter-linux-x86_64 translate workflow/ output/ --ruleset {{RULESET}}
+    LOG_LEVEL=DEBUG ./orbiter-linux-x86_64 translate workflow/ output/ --ruleset {{RULESET}} --no-format && \
     echo "[ORBITER DOCUMENT]" && \
-    LOG_LEVEL=DEBUG orbiter document --ruleset {{RULESET}} && \
+    LOG_LEVEL=DEBUG ./orbiter-linux-x86_64 document --ruleset {{RULESET}} && \
     head translation_ruleset.html
     EOF
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ description = "Astronomer Orbiter can take your legacy workloads and land them s
 readme = "README.md"
 authors = [
     { name = "Fritz Davenport", email = "fritz@astronomer.io" },
-    { name = "CETA Team", email = "ceta@astronomer.io" },
     { name = "Astronomer", email = "humans@astronomer.io" },
 ]
 license = { file = "LICENSE" }
@@ -79,6 +78,13 @@ dependencies = [
 
     # backport
     "eval_type_backport; python_version < '3.10'",
+
+    # for 'document' command
+    "mkdocs",
+    "mkdocs-material",
+    "pygments",
+    "mkdocstrings-python",
+    "htmlark"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Command to emit a single-page HTML document for a translation module.
Reuses mkdocs and plugins that generate other orbiter docs