### PR TITLE
Update Ubuntu version in GHA Runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: [ "3.10" ]
         os:
           # --8<-- [start:oses]
-          - "ubuntu-20.04"
+          - "ubuntu-22.04"
           - "windows-latest"
           - "macos-latest"  # M1 Mac
           - "macos-13"  # Intel Mac


### PR DESCRIPTION
- fix: update ubuntu in cicd build, v20 is yanked