### PR TITLE
Fix Relative Imports (e.g. `--ruleset=override.translation_ruleset`)

### DIFF
--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import re
+import sys
+from pathlib import Path
 from typing import Any, Tuple
+
+from loguru import logger
 
 __version__ = "1.5.5"
 
@@ -38,6 +42,24 @@ def clean_value(s: str):
     s = re.sub("[^A-Za-z0-9_.]", "", s)  # remove anything that isn't alphanum or _ or .
     s = re.sub(r"^(\d)", r"n\1", s)  # prefix a number at the start with an "n"
     return s
+
+
+def insert_cwd_to_sys_path():
+    """Insert the current directory to `sys.path`, if it is not already there.
+
+    This is used for finding translation rulesets locally (or as a `.pyz`, locally)
+
+    ```pycon
+    >>> (path := str(Path.cwd())) in sys.path
+    False
+    >>> insert_cwd_to_sys_path()
+    >>> path in sys.path
+    True
+    """
+    cwd = Path.cwd()
+    logger.debug(f"Adding current directory {cwd} to sys.path")
+    if str(cwd) not in sys.path:
+        sys.path.insert(0, str(cwd))
 
 
 def import_from_qualname(qualname) -> Tuple[str, Any]:

--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any, Tuple
 
-__version__ = "1.5.4"
+__version__ = "1.5.5"
 
 version = __version__
 

--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -50,7 +50,9 @@ def insert_cwd_to_sys_path():
     This is used for finding translation rulesets locally (or as a `.pyz`, locally)
 
     ```pycon
-    >>> (path := str(Path.cwd())) in sys.path
+    >>>  # setup - del from sys.path if it's there
+    ... path = str(Path.cwd()); sys.path = [p for p in sys.path if p != path]
+    >>> path in sys.path
     False
     >>> insert_cwd_to_sys_path()
     >>> path in sys.path

--- a/orbiter/__main__.py
+++ b/orbiter/__main__.py
@@ -177,10 +177,15 @@ def import_ruleset(ruleset: str) -> TranslationRuleset:
     try:
         (_, translation_ruleset) = import_from_qualname(ruleset)
     except ModuleNotFoundError:
-        logger.error(
-            f"Error importing ruleset: {ruleset}!\nTranslations must already be installed with `orbiter install`!"
-        )
-        raise click.Abort()
+        try:
+            logger.debug("ModuleNotFound error! Adding current directory to sys.path and trying again")
+            sys.path.append(".")
+            (_, translation_ruleset) = import_from_qualname(ruleset)
+        except ModuleNotFoundError:
+            logger.error(
+                f"Error importing ruleset: {ruleset}!\nTranslations must already be installed with `orbiter install`!"
+            )
+            raise click.Abort()
     if not isinstance(translation_ruleset, TranslationRuleset):
         raise RuntimeError(f"translation_ruleset={translation_ruleset} is not a TranslationRuleset")
     return translation_ruleset


### PR DESCRIPTION
- fix: allow relative import by adding to syspath if ModuleNotFoundError