### PR TITLE
TaskGroup downstream fix

### DIFF
--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -11,7 +11,7 @@ from pydantic import AfterValidator
 
 from orbiter.config import TRIM_LOG_OBJECT_LENGTH
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"
 
 version = __version__
 

--- a/orbiter/ast_helper.py
+++ b/orbiter/ast_helper.py
@@ -163,6 +163,8 @@ def py_reference(name: str) -> ast.Expr:
 
 
 def render_ast(ast_object) -> str:
+    if ast_object is None:
+        return ""
     return ast.unparse(ast_object)
 
 

--- a/orbiter/default_translation.py
+++ b/orbiter/default_translation.py
@@ -57,7 +57,7 @@ def file_relative_to_parent(file: Path, parent: Path) -> Path:
     """
     file_resolved = file.resolve()
     try:
-        file_relative_to_input_dir_parent = file_resolved.relative_to(parent.parent)
+        file_relative_to_input_dir_parent = file_resolved.relative_to(parent.parent.resolve())
     except ValueError as e:
         logger.opt(exception=e).warning(f"File {file_resolved} is not relative to {parent.parent}")
         file_relative_to_input_dir_parent = file_resolved

--- a/orbiter/objects/tasks_parent_shared_utils.py
+++ b/orbiter/objects/tasks_parent_shared_utils.py
@@ -54,10 +54,13 @@ def _get_task_dependency_parent(
     ```
     """
     from orbiter.objects.task_group import OrbiterTaskGroup
+    from orbiter.objects.task import OrbiterTaskDependency
+
+    task_id = task_dependency.task_id if isinstance(task_dependency, OrbiterTaskDependency) else task_dependency
 
     for task in getattr(self, "tasks", {}).values():
         found = None
-        if getattr(task, "task_id", "") == task_dependency.task_id:
+        if getattr(task, "task_id", "") == task_id:
             found = self
         elif isinstance(task, OrbiterTaskGroup):
             if _found := _get_task_dependency_parent(task, task_dependency):

--- a/tests/orbiter/objects/task_group_test.py
+++ b/tests/orbiter/objects/task_group_test.py
@@ -15,8 +15,7 @@ def test_task_group_rendering():
     expected = r"""from airflow import DAG
 from airflow.operators.empty import EmptyOperator
 from airflow.utils.task_group import TaskGroup
-from pendulum import DateTime, Timezone
-with DAG(dag_id='dag', schedule=None, start_date=DateTime(1970, 1, 1, 0, 0, 0), catchup=False):
+with DAG(dag_id='dag'):
     with TaskGroup(group_id='foo') as foo:
         a_task = EmptyOperator(task_id='a')
     with TaskGroup(group_id='bar') as bar:

--- a/tests/orbiter/objects/task_group_test.py
+++ b/tests/orbiter/objects/task_group_test.py
@@ -21,6 +21,5 @@ with DAG(dag_id='dag', schedule=None, start_date=DateTime(1970, 1, 1, 0, 0, 0), 
         a_task = EmptyOperator(task_id='a')
     with TaskGroup(group_id='bar') as bar:
         b_task = EmptyOperator(task_id='b')
-    foo >> bar
-"""
+    foo >> bar"""  # noqa
     assert str(actual) == expected

--- a/tests/orbiter/objects/task_group_test.py
+++ b/tests/orbiter/objects/task_group_test.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+from orbiter.objects.dag import OrbiterDAG
+from orbiter.objects.operators.empty import OrbiterEmptyOperator
+from orbiter.objects.task_group import OrbiterTaskGroup
+
+
+def test_task_group_rendering():
+    actual = OrbiterDAG(dag_id="dag", file_path=Path.cwd()).add_tasks(
+        [
+            OrbiterTaskGroup(task_group_id="foo").add_tasks([OrbiterEmptyOperator(task_id="a")]).add_downstream("bar"),
+            OrbiterTaskGroup(task_group_id="bar").add_tasks([OrbiterEmptyOperator(task_id="b")]),
+        ]
+    )
+    expected = r"""from airflow import DAG
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.task_group import TaskGroup
+from pendulum import DateTime, Timezone
+with DAG(dag_id='dag', schedule=None, start_date=DateTime(1970, 1, 1, 0, 0, 0), catchup=False):
+    with TaskGroup(group_id='foo') as foo:
+        a_task = EmptyOperator(task_id='a')
+    with TaskGroup(group_id='bar') as bar:
+        b_task = EmptyOperator(task_id='b')
+    foo >> bar
+"""
+    assert str(actual) == expected


### PR DESCRIPTION
- fix: render_ast gracefully handle None
- refactor: extract downstream_to_ast to common module
- feat: add `get_rendered_task_id` - to have an object say if it wants "_task" or not, rather than guessing at dependency time
- feat: add dereferenced_downstream - to figure out which operator belongs to which task_id to see if it's a task_group

Closes #69 