### PR TITLE
Params Doc for Rules & OrbiterMeta

### DIFF
--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -11,7 +11,7 @@ from pydantic import AfterValidator
 
 from orbiter.config import TRIM_LOG_OBJECT_LENGTH
 
-__version__ = "1.8.4"
+__version__ = "1.9.0"
 
 version = __version__
 

--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -11,7 +11,7 @@ from pydantic import AfterValidator
 
 from orbiter.config import TRIM_LOG_OBJECT_LENGTH
 
-__version__ = "1.8.3"
+__version__ = "1.8.4"
 
 version = __version__
 

--- a/orbiter/meta.py
+++ b/orbiter/meta.py
@@ -12,6 +12,10 @@ class OrbiterMeta(BaseModel):
     matched_rule_docstring: Annotated[
         str | None, Field(default=None, description="The documentation of the rule that matched the input.")
     ]
+    matched_rule_params_doc: Annotated[
+        dict[str, str] | None,
+        Field(default=None, description="The documentation of parameters that the rule consumed and emitted."),
+    ]
     matched_rule_name: Annotated[
         str | None, Field(default=None, description="The name of the rule that matched the input.")
     ]

--- a/orbiter/rules/__init__.py
+++ b/orbiter/rules/__init__.py
@@ -158,6 +158,8 @@ class Rule(BaseModel, Callable, extra="forbid"):
     :type rule: Callable[[dict | Any], Any | None]
     :param priority: Higher priority rules are evaluated first, must be greater than 0. Default is 0
     :type priority: int, optional
+    :param params_doc: What the rule takes as input (key), and gives as output (value)
+    :type params_doc: dict[str, str], optional
     """
 
     rule: Callable[[dict | Any], Any | None]

--- a/orbiter/rules/__init__.py
+++ b/orbiter/rules/__init__.py
@@ -101,9 +101,11 @@ class Rule(BaseModel, Callable, extra="forbid"):
 
     The function in a rule takes one parameter (`val`), and **must always evaluate to *something* or *nothing*.**
     ```pycon
-    >>> Rule(rule=lambda val: 4)(val={})
+    >>> some_rule = Rule(rule=lambda val: 4)  # returns something
+    >>> some_rule(val={})  # always takes "val", in this case a dict
     4
-    >>> Rule(rule=lambda val: None)(val={})
+    >>> other_rule = Rule(rule=lambda val: None)  # returns nothing
+    >>> other_rule(val={})
 
     ```
     Depending on the type of rule, the input `val` may be a dictionary or a different type.
@@ -117,7 +119,7 @@ class Rule(BaseModel, Callable, extra="forbid"):
 
         ```pycon
         >>> from orbiter.rules import task_rule
-        >>> @task_rule
+        >>> @task_rule(params_doc={"id": "BashOperator.task_id", "command": "BashOperator.bash_command"})
         ... def my_rule(val: dict):
         ...     '''This rule takes that and gives this'''
         ...     from orbiter.objects.operators.bash import OrbiterBashOperator
@@ -133,9 +135,10 @@ class Rule(BaseModel, Callable, extra="forbid"):
         {'val': {'id': 'foo', 'command': "echo 'hello world'", 'unvisited_key': 'bar'}}
         >>> match.orbiter_meta
         ... # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-        OrbiterMeta(matched_rule_source="@task_rule...",
+        OrbiterMeta(matched_rule_source='@task_rule...',
             matched_rule_docstring='This rule takes that and gives this',
-            matched_rule_params_doc=None, matched_rule_name='my_rule',
+            matched_rule_params_doc={'id': 'BashOperator.task_id', 'command': 'BashOperator.bash_command'},
+            matched_rule_name='my_rule',
             matched_rule_priority=1,
             visited_keys=['command', 'id'])
 


### PR DESCRIPTION
- feat: add params_doc to rules & OrbiterMeta

Allows for 
```
@rule(params_doc={"foo": "bar"})
```
to document what is consumed and emitted in a more easily readable/parsable fashion