### PR TITLE
`@pattern` Decorator

### DIFF
--- a/orbiter/rules/__init__.py
+++ b/orbiter/rules/__init__.py
@@ -243,7 +243,7 @@ class Pattern(BaseModel, Callable, extra="forbid"):
     ```
     """
 
-    pattern: Callable[[dict | Any, ...], dict | Any | None]
+    pattern: Callable[..., dict | Any | None]
     params_doc: dict[str, str] | None = None
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
# Why
I have been having conversations with folks along the lines of "rule composability".

I am considering the idea that things like [`task_common_args`](https://github.com/astronomer/orbiter-community-translations/blob/main/orbiter_translations/cron/crontab_base.py#L78-L94) could be a "Pattern", which I think fits with how creating translations is discussed.

1. Translations have rulesets,
2. rulesets have rules,
3. rules have patterns. 

Ultimately the complexity of a translation is in the "number of patterns" that need to be covered. 

WDYT?

## Caveats
This addition doesn't enforce any structure of the pattern, nor that an `@rule` uses them 
(you can have a gigantic rule that does a million things - they are _supposed to do one thing, but not required to_)

This just gives an opportunity to document inputs/outputs and encourages composability and reuse

# Example
## Before / After
Is fairly similar - as this addition is just an indication / hint towards structure.

```diff
from orbiter.objects.operators.bash import OrbiterBashOperator
+ from orbiter.rules import task_rule, pattern

+ @pattern(params_doc={"command": "Operator.bash_command"})
- command_pattern_params_doc={"command": "Operator.bash_command"}
def command_pattern(val: dict) -> dict:
    if 'command' in val:
        return {"bash_command": val['command']}
    else:
        return {}

- @task_rule(params_doc={"id": "Operator.task_id"} | command_pattern_params_doc)  # params_doc composition
+ @task_rule(params_doc={"id": "Operator.task_id"} | command_pattern.params_doc)  # params_doc composition
def bash_rule(val: dict) -> OrbiterBashOperator | None:
    return OrbiterBashOperator(
        task_id=val['id'],
        **command_pattern(val),                              # pattern output can be added, or not
    ) if 'id' in val and 'command' in val else None          # rules still produce one something or nothing
```
```pycon
>>> bash_rule(val={"id": "foo", "command": "echo 'hello world'"})
foo_task = BashOperator(task_id='foo', bash_command="echo 'hello world'")
```

