### PR TITLE
Add OrbiterInclude+OrbiterRequirement helper utility

### DIFF
--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -11,7 +11,7 @@ from pydantic import AfterValidator
 
 from orbiter.config import TRIM_LOG_OBJECT_LENGTH
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 
 version = __version__
 

--- a/orbiter/objects/include.py
+++ b/orbiter/objects/include.py
@@ -103,9 +103,16 @@ class OrbiterInclude(BaseModel, extra="forbid"):
         else:
             file_extension = include_filepath.rsplit(".", maxsplit=1)[-1]
 
+        spec = find_spec(include_module_qualname)
+        if spec is None or spec.origin is None:
+            raise ImportError(
+                f"Cannot find module specification for '{include_module_qualname}'. "
+                "Ensure the module is importable and available on PYTHONPATH."
+            )
+
         return OrbiterInclude(
             filepath=include_filepath,
-            contents=Path(find_spec(include_module_qualname).origin).read_text(),
+            contents=Path(spec.origin).read_text(),
         ), OrbiterRequirement(
             module=include_filepath.replace("/", ".").replace("." + file_extension, ""),
             names=import_names,

--- a/orbiter/objects/include.py
+++ b/orbiter/objects/include.py
@@ -83,9 +83,9 @@ class OrbiterInclude(BaseModel, extra="forbid"):
         :type import_names: list[str]
         :param include_filepath: Optional filepath to write the include to creating the file as `include/???.py`
         :type include_filepath: str, optional
-        :param import_package: Optional Python package, to add the the project if specified.
+        :param import_package: Optional Python package, to add to the project if specified.
         :type import_package: str, optional
-        :param import_sys_package: Optional Debian package, to add the the project if specified.
+        :param import_sys_package: Optional Debian package, to add to the project if specified.
         :type import_sys_package: str, optional
         :return: A tuple of the [OrbiterInclude][orbiter.objects.include.OrbiterInclude] and [OrbiterRequirement][orbiter.objects.requirement.OrbiterRequirement]
         """

--- a/orbiter/objects/include.py
+++ b/orbiter/objects/include.py
@@ -79,7 +79,7 @@ class OrbiterInclude(BaseModel, extra="forbid"):
         ```
         :param include_module_qualname: The qualified name of the module to include, e.g. `orbiter.objects.include` for this module.
         :type include_module_qualname: str
-        :param import_names: The names to import from the module, e.g. `["OrbiterInclude"]` for the `OrbiterInclude` class.
+        :param import_names: The names to import from the module, e.g. `["OrbiterInclude"]` for this class.
         :type import_names: list[str]
         :param include_filepath: Optional filepath to write the include to creating the file as `include/???.py`
         :type include_filepath: str, optional


### PR DESCRIPTION
- feat(objects): Add helper to quickly get an orbiter include and requirement from a qualname of a py file

---

I found myself regularly needing to 
1. make a `.py` file for some function I wanted to include in Airflow, for a translation feature (in a special directory so it's separated from the translation, so the translations don't require `airflow`)
2. needing to add a `OrbiterInclude` for that `.py` file
3. needing to add a `OrbiterRequirement` to import it

I figured it'd be nice to have a shortcut.

## Example: 

### Airflow Project Included File / Utility
```python
# orbiter_translation/some_system/include/cool_utilities.py
from airflow import ...

def cool_utility_function(...):
    """this does some cool utility function to help an airflow operator or etc"""
    ...
```

---

### Orbiter Translation
```diff
# orbiter_translation/some_system/translation.py

# note: `find_spec` is required for portability
# it could be compiled and running within a packed binary or .pyz
-  cool_utility_include = OrbiterInclude(
-    filepath='include/cool_utilities.py', 
-    contents=Path(find_spec("orbiter_translations.some_system.include.cool_utilities").origin).read_text()
- )
- cool_utility_function_import = OrbiterRequirement(
-    names=["cool_utility_function"],
-    module="include.cool_utilities"
- )
+ cool_utility_include, cool_utility_function_import =  OrbiterInclude.get_include_and_requirement(
+    include_module_qualname="orbiter_translation/some_system/include/cool_utilities",
+    import_names=["cool_utility_function"]
+ )
```
```python
# orbiter_translation/some_system/translation.py
@task_rule
def some_rule(val: dict) -> OrbiterTask | None:
    if ... : 
        return OrbiterTask(
            imports=[cool_utility_function_import]
            orbiter_includes={cool_utility_include}
            ...
        )
    return None
```


