### PR TITLE
Update CICD GHA runner to supported Intel Mac

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
           - "ubuntu-22.04"
           - "windows-latest"
           - "macos-latest"  # M1 Mac
-          - "macos-13"  # Intel Mac
+          - "macos-15-intel"  # Intel Mac
           # --8<-- [end:oses]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
- cicd: update GHA runner to supported mac intel

---

https://github.com/actions/runner-images/issues/13046
https://github.com/actions/runner-images/issues/13045
> the new label will run on macOS 15 and will be available from now until August 2027. This will be the last available x86_64 image from Actions, and after that date the x86_64 architecture will not be supported on GitHub Actions.

