### PR TITLE
Find `ruff` more effectively for linting/formatting step

### DIFF
--- a/orbiter/__init__.py
+++ b/orbiter/__init__.py
@@ -11,7 +11,7 @@ from pydantic import AfterValidator
 
 from orbiter.config import TRIM_LOG_OBJECT_LENGTH
 
-__version__ = "1.10.2"
+__version__ = "1.10.3"
 
 version = __version__
 

--- a/orbiter/__main__.py
+++ b/orbiter/__main__.py
@@ -192,7 +192,7 @@ def import_ruleset(ruleset: str) -> TranslationRuleset:
     return translation_ruleset
 
 
-def run(cmd: str | list[str], **kwargs):
+def run(cmd: str, **kwargs):
     """Helper method to run a command and log the output"""
     from loguru import logger
 

--- a/orbiter/__main__.py
+++ b/orbiter/__main__.py
@@ -213,11 +213,14 @@ def run_ruff_formatter(output_dir: Path):
         def find_ruff_bin():
             return shutil.which("ruff")
 
-        if find_ruff_bin() is None:
-            logger.error("Ruff is not installed, please install it with `pip install ruff`")
-            raise click.Abort()
-
     logger.info("Reformatting output...")
+
+    if find_ruff_bin() is None:
+        logger.error(
+            "Ruff is required to reformat output, but is not installed. Please install it with `pip install ruff`"
+        )
+        raise click.Abort()
+
     changed_files = output_dir
     # noinspection PyBroadException
     try:

--- a/orbiter/__main__.py
+++ b/orbiter/__main__.py
@@ -215,47 +215,51 @@ def run_ruff_formatter(output_dir: Path):
 
     logger.info("Reformatting output...")
 
-    if find_ruff_bin() is None:
-        logger.error(
+    if (ruff := find_ruff_bin()) is None:
+        logger.warning(
             "Ruff is required to reformat output, but is not installed. Please install it with `pip install ruff`"
         )
-        raise click.Abort()
+        logger.error("Formatting step failed, skipping formatting")
+    else:
+        changed_files = output_dir
+        # noinspection PyBroadException
+        try:
+            # noinspection PyUnresolvedReferences
+            import git
 
-    changed_files = output_dir
-    # noinspection PyBroadException
-    try:
-        # noinspection PyUnresolvedReferences
-        import git
-
-        changed_files = " ".join(
-            (
-                file
-                for file in git.Repo(output_dir).git.diff(output_dir, name_only=True).split("\n")
-                if file.endswith(".py")
+            changed_files = " ".join(
+                (
+                    file
+                    for file in git.Repo(output_dir).git.diff(output_dir, name_only=True).split("\n")
+                    if file.endswith(".py")
+                )
             )
+        except ImportError:
+            logger.debug(
+                "Unable to acquire list of changed files in output directory, reformatting output directory..."
+            )
+        except Exception:
+            logger.debug(
+                "Unable to acquire list of changed files in output directory, reformatting output directory..."
+            )
+
+        output = run(
+            f"{ruff} check --select E,F,UP,B,SIM,I --ignore E501,SIM117,SIM101 --fix {changed_files}",
+            shell=True,
+            text=True,
+            capture_output=True,
         )
-    except ImportError:
-        logger.debug("Unable to acquire list of changed files in output directory, reformatting output directory...")
-    except Exception:
-        logger.debug("Unable to acquire list of changed files in output directory, reformatting output directory...")
+        if output.returncode != 0:
+            click.echo("Ruff encountered an error!")
+            raise click.Abort()
 
-    output = run(
-        f"{find_ruff_bin()} check --select E,F,UP,B,SIM,I --ignore E501,SIM117,SIM101 --fix {changed_files}",
-        shell=True,
-        text=True,
-        capture_output=True,
-    )
-    if output.returncode != 0:
-        click.echo("Ruff encountered an error!")
-        raise click.Abort()
-
-    run(
-        f"{find_ruff_bin()} format {changed_files}",
-        shell=True,
-        text=True,
-        check=True,
-        capture_output=True,
-    )
+        run(
+            f"{ruff} format {changed_files}",
+            shell=True,
+            text=True,
+            check=True,
+            capture_output=True,
+        )
 
 
 @click.group(
@@ -328,6 +332,10 @@ def translate(
         raise click.Abort()
     if _format:
         run_ruff_formatter(output_dir)
+    logger.info(f"Translation completed. Output={output_dir}")
+    logger.info(
+        "Next steps - run `astro dev init` to create a complete Airflow Project, and `astro dev start` to run it!"
+    )
 
 
 @orbiter.command()


### PR DESCRIPTION
utilizes https://github.com/astral-sh/ruff/blob/main/python/ruff/__main__.py#L8
Falls back to `shutil.which('ruff')`

---

- fix(formatter): find ruff more effectively
- fix(cli): improve formatting logging
- fix(cli): better logging for formatting and translation complete
